### PR TITLE
feat: Add MaterialType and QuestionType enums (#17, #18)

### DIFF
--- a/android/app/src/main/java/com/manuscripta/student/data/model/MaterialType.java
+++ b/android/app/src/main/java/com/manuscripta/student/data/model/MaterialType.java
@@ -1,0 +1,47 @@
+package com.manuscripta.student.data.model;
+
+/**
+ * Enum representing different types of materials that can be delivered to students.
+ * Used to categorize educational content in the Manuscripta system.
+ */
+public enum MaterialType {
+    /**
+     * Reading lesson content - informational text for students to read and learn from
+     */
+    LESSON,
+
+    /**
+     * Assessment with questions - tests student understanding
+     */
+    QUIZ,
+
+    /**
+     * Practice exercises - activities for students to complete
+     */
+    WORKSHEET,
+
+    /**
+     * Quick survey or poll - gather student opinions or check understanding
+     */
+    POLL;
+
+    /**
+     * Get a human-readable display name for this material type.
+     *
+     * @return Display name suitable for UI
+     */
+    public String getDisplayName() {
+        switch (this) {
+            case LESSON:
+                return "Reading Material";
+            case QUIZ:
+                return "Quiz";
+            case WORKSHEET:
+                return "Worksheet";
+            case POLL:
+                return "Poll";
+            default:
+                return "";
+        }
+    }
+}

--- a/android/app/src/main/java/com/manuscripta/student/data/model/QuestionType.java
+++ b/android/app/src/main/java/com/manuscripta/student/data/model/QuestionType.java
@@ -1,0 +1,49 @@
+package com.manuscripta.student.data.model;
+
+/**
+ * Enum representing different types of questions that can appear in quizzes.
+ * Used to determine how questions should be displayed and answered.
+ */
+public enum QuestionType {
+    /**
+     * Multiple choice question with several options (A, B, C, D)
+     */
+    MULTIPLE_CHOICE,
+
+    /**
+     * True or False question
+     */
+    TRUE_FALSE,
+
+    /**
+     * Short answer - student types their response
+     */
+    SHORT_ANSWER;
+
+    /**
+     * Check if this question type requires predefined options.
+     *
+     * @return true if options are needed (multiple choice, true/false)
+     */
+    public boolean requiresOptions() {
+        return this == MULTIPLE_CHOICE || this == TRUE_FALSE;
+    }
+
+    /**
+     * Get a human-readable display name for this question type.
+     *
+     * @return Display name suitable for UI
+     */
+    public String getDisplayName() {
+        switch (this) {
+            case MULTIPLE_CHOICE:
+                return "Multiple Choice";
+            case TRUE_FALSE:
+                return "True/False";
+            case SHORT_ANSWER:
+                return "Short Answer";
+            default:
+                return "";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds two new enum classes to support material types and question types in the student data model.

  ## Changes
  - Add `MaterialType` enum with values: LESSON, QUIZ, WORKSHEET, POLL
  - Add `QuestionType` enum with values: MULTIPLE_CHOICE, TRUE_FALSE, SHORT_ANSWER
  - Include helper methods for display names and validation

Closes #17
Closes #18