### PR TITLE
[Android] refactor: Rename selectedAnswer to answer in Response classes

### DIFF
--- a/android/app/src/main/java/com/manuscripta/student/data/model/ResponseEntity.java
+++ b/android/app/src/main/java/com/manuscripta/student/data/model/ResponseEntity.java
@@ -34,9 +34,9 @@ public class ResponseEntity {
     @NonNull
     private final String questionId;
 
-    /** The answer selected by the student. */
+    /** The answer provided by the student. */
     @NonNull
-    private final String selectedAnswer;
+    private final String answer;
 
     /** Whether the response is correct. */
     private final boolean isCorrect;
@@ -55,24 +55,24 @@ public class ResponseEntity {
      * Standard constructor used by Room to recreate objects from the database.
      * Pass the existing ID explicitly.
      *
-     * @param id             The unique identifier for the response
-     * @param questionId     The ID of the question this response is for
-     * @param selectedAnswer The answer selected by the student
-     * @param isCorrect      Whether the response is correct
-     * @param timestamp      The timestamp when the response was recorded
-     * @param synced         Whether the response has been synced
-     * @param deviceId       The device identifier for the tablet that submitted this response
+     * @param id         The unique identifier for the response
+     * @param questionId The ID of the question this response is for
+     * @param answer     The answer provided by the student
+     * @param isCorrect  Whether the response is correct
+     * @param timestamp  The timestamp when the response was recorded
+     * @param synced     Whether the response has been synced
+     * @param deviceId   The device identifier for the tablet that submitted this response
      */
     public ResponseEntity(@NonNull String id,
                           @NonNull String questionId,
-                          @NonNull String selectedAnswer,
+                          @NonNull String answer,
                           boolean isCorrect,
                           long timestamp,
                           boolean synced,
                           @NonNull String deviceId) {
         this.id = id;
         this.questionId = questionId;
-        this.selectedAnswer = selectedAnswer;
+        this.answer = answer;
         this.isCorrect = isCorrect;
         this.timestamp = timestamp;
         this.synced = synced;
@@ -92,8 +92,8 @@ public class ResponseEntity {
     }
 
     @NonNull
-    public String getSelectedAnswer() {
-        return selectedAnswer;
+    public String getAnswer() {
+        return answer;
     }
 
     public boolean isCorrect() {

--- a/android/app/src/main/java/com/manuscripta/student/domain/mapper/ResponseMapper.java
+++ b/android/app/src/main/java/com/manuscripta/student/domain/mapper/ResponseMapper.java
@@ -29,7 +29,7 @@ public final class ResponseMapper {
         return new Response(
                 entity.getId(),
                 entity.getQuestionId(),
-                entity.getSelectedAnswer(),
+                entity.getAnswer(),
                 entity.isCorrect(),
                 entity.getTimestamp(),
                 entity.isSynced(),
@@ -48,7 +48,7 @@ public final class ResponseMapper {
         return new ResponseEntity(
                 domain.getId(),
                 domain.getQuestionId(),
-                domain.getSelectedAnswer(),
+                domain.getAnswer(),
                 domain.isCorrect(),
                 domain.getTimestamp(),
                 domain.isSynced(),

--- a/android/app/src/main/java/com/manuscripta/student/domain/model/Response.java
+++ b/android/app/src/main/java/com/manuscripta/student/domain/model/Response.java
@@ -20,9 +20,9 @@ public class Response {
     @NonNull
     private final String questionId;
 
-    /** The answer selected by the student. */
+    /** The answer provided by the student. */
     @NonNull
-    private final String selectedAnswer;
+    private final String answer;
 
     /** Whether the response is correct. */
     private final boolean isCorrect;
@@ -41,23 +41,23 @@ public class Response {
      * Factory method for creating a NEW response.
      * Generates a random UUID, captures the current timestamp, and sets default values.
      *
-     * @param questionId     UUID of the parent question
-     * @param selectedAnswer The student's selected answer
-     * @param deviceId       The device identifier for the tablet submitting this response
+     * @param questionId UUID of the parent question
+     * @param answer     The student's answer
+     * @param deviceId   The device identifier for the tablet submitting this response
      * @return A new Response instance with generated ID and default values
      * @throws IllegalArgumentException if questionId is null or empty
-     * @throws IllegalArgumentException if selectedAnswer is null
+     * @throws IllegalArgumentException if answer is null
      * @throws IllegalArgumentException if deviceId is null or empty
      */
     @NonNull
     public static Response create(@NonNull String questionId,
-                                  @NonNull String selectedAnswer,
+                                  @NonNull String answer,
                                   @NonNull String deviceId) {
         if (questionId == null || questionId.trim().isEmpty()) {
             throw new IllegalArgumentException("Response questionId cannot be null or empty");
         }
-        if (selectedAnswer == null) {
-            throw new IllegalArgumentException("Response selectedAnswer cannot be null");
+        if (answer == null) {
+            throw new IllegalArgumentException("Response answer cannot be null");
         }
         if (deviceId == null || deviceId.trim().isEmpty()) {
             throw new IllegalArgumentException("Response deviceId cannot be null or empty");
@@ -65,7 +65,7 @@ public class Response {
         return new Response(
                 UUID.randomUUID().toString(),
                 questionId,
-                selectedAnswer,
+                answer,
                 false,
                 System.currentTimeMillis(),
                 false,
@@ -76,22 +76,22 @@ public class Response {
     /**
      * Constructor with all fields.
      *
-     * @param id             Unique identifier (UUID)
-     * @param questionId     UUID of the parent question
-     * @param selectedAnswer The student's selected answer
-     * @param isCorrect      Whether the response is correct
-     * @param timestamp      When the response was recorded (Unix epoch milliseconds)
-     * @param synced         Whether response has been synced to teacher's Windows app
-     * @param deviceId       The device identifier for the tablet that submitted this response
+     * @param id         Unique identifier (UUID)
+     * @param questionId UUID of the parent question
+     * @param answer     The student's answer
+     * @param isCorrect  Whether the response is correct
+     * @param timestamp  When the response was recorded (Unix epoch milliseconds)
+     * @param synced     Whether response has been synced to teacher's Windows app
+     * @param deviceId   The device identifier for the tablet that submitted this response
      * @throws IllegalArgumentException if id is null or empty
      * @throws IllegalArgumentException if questionId is null or empty
-     * @throws IllegalArgumentException if selectedAnswer is null
+     * @throws IllegalArgumentException if answer is null
      * @throws IllegalArgumentException if timestamp is negative
      * @throws IllegalArgumentException if deviceId is null or empty
      */
     public Response(@NonNull String id,
                     @NonNull String questionId,
-                    @NonNull String selectedAnswer,
+                    @NonNull String answer,
                     boolean isCorrect,
                     long timestamp,
                     boolean synced,
@@ -102,8 +102,8 @@ public class Response {
         if (questionId == null || questionId.trim().isEmpty()) {
             throw new IllegalArgumentException("Response questionId cannot be null or empty");
         }
-        if (selectedAnswer == null) {
-            throw new IllegalArgumentException("Response selectedAnswer cannot be null");
+        if (answer == null) {
+            throw new IllegalArgumentException("Response answer cannot be null");
         }
         if (timestamp < 0) {
             throw new IllegalArgumentException("Response timestamp cannot be negative");
@@ -114,7 +114,7 @@ public class Response {
 
         this.id = id;
         this.questionId = questionId;
-        this.selectedAnswer = selectedAnswer;
+        this.answer = answer;
         this.isCorrect = isCorrect;
         this.timestamp = timestamp;
         this.synced = synced;
@@ -132,8 +132,8 @@ public class Response {
     }
 
     @NonNull
-    public String getSelectedAnswer() {
-        return selectedAnswer;
+    public String getAnswer() {
+        return answer;
     }
 
     public boolean isCorrect() {

--- a/android/app/src/test/java/com/manuscripta/student/data/local/ResponseDaoTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/data/local/ResponseDaoTest.java
@@ -101,7 +101,7 @@ public class ResponseDaoTest {
         assertNotNull(retrieved);
         assertEquals("r-1", retrieved.getId());
         assertEquals("q-1", retrieved.getQuestionId());
-        assertEquals("4", retrieved.getSelectedAnswer());
+        assertEquals("4", retrieved.getAnswer());
         assertTrue(retrieved.isCorrect());
     }
 
@@ -208,7 +208,7 @@ public class ResponseDaoTest {
         responseDao.update(updatedResponse);
 
         ResponseEntity retrieved = responseDao.getById("r-1");
-        assertEquals("3", retrieved.getSelectedAnswer());
+        assertEquals("3", retrieved.getAnswer());
         assertFalse(retrieved.isCorrect());
     }
 
@@ -312,7 +312,7 @@ public class ResponseDaoTest {
         responseDao.insert(updated);
 
         ResponseEntity retrieved = responseDao.getById("r-1");
-        assertEquals("4", retrieved.getSelectedAnswer());
+        assertEquals("4", retrieved.getAnswer());
         assertEquals(1, responseDao.getCount());
     }
 }

--- a/android/app/src/test/java/com/manuscripta/student/data/model/ResponseEntityTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/data/model/ResponseEntityTest.java
@@ -28,7 +28,7 @@ public class ResponseEntityTest {
         assertNotNull(response);
         assertEquals("response-1", response.getId());
         assertEquals("q-1", response.getQuestionId());
-        assertEquals("4", response.getSelectedAnswer());
+        assertEquals("4", response.getAnswer());
         assertTrue(response.isCorrect());
         assertEquals(1000L, response.getTimestamp());
         assertTrue(response.isSynced());
@@ -49,7 +49,7 @@ public class ResponseEntityTest {
 
         assertEquals("response-2", response.getId());
         assertEquals("q-2", response.getQuestionId());
-        assertEquals("3", response.getSelectedAnswer());
+        assertEquals("3", response.getAnswer());
         assertFalse(response.isCorrect());
         assertEquals(2000L, response.getTimestamp());
         assertFalse(response.isSynced());

--- a/android/app/src/test/java/com/manuscripta/student/domain/mapper/ResponseMapperTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/domain/mapper/ResponseMapperTest.java
@@ -36,7 +36,7 @@ public class ResponseMapperTest {
         assertNotNull(domain);
         assertEquals(entity.getId(), domain.getId());
         assertEquals(entity.getQuestionId(), domain.getQuestionId());
-        assertEquals(entity.getSelectedAnswer(), domain.getSelectedAnswer());
+        assertEquals(entity.getAnswer(), domain.getAnswer());
         assertEquals(entity.isCorrect(), domain.isCorrect());
         assertEquals(entity.getTimestamp(), domain.getTimestamp());
         assertEquals(entity.isSynced(), domain.isSynced());
@@ -63,7 +63,7 @@ public class ResponseMapperTest {
         assertNotNull(entity);
         assertEquals(domain.getId(), entity.getId());
         assertEquals(domain.getQuestionId(), entity.getQuestionId());
-        assertEquals(domain.getSelectedAnswer(), entity.getSelectedAnswer());
+        assertEquals(domain.getAnswer(), entity.getAnswer());
         assertEquals(domain.isCorrect(), entity.isCorrect());
         assertEquals(domain.getTimestamp(), entity.getTimestamp());
         assertEquals(domain.isSynced(), entity.isSynced());
@@ -90,7 +90,7 @@ public class ResponseMapperTest {
         assertNotNull(domain);
         assertTrue(domain.isCorrect());
         assertTrue(domain.isSynced());
-        assertEquals("Answer A", domain.getSelectedAnswer());
+        assertEquals("Answer A", domain.getAnswer());
         assertEquals("device-id-synced", domain.getDeviceId());
     }
 
@@ -114,7 +114,7 @@ public class ResponseMapperTest {
         assertNotNull(domain);
         assertFalse(domain.isCorrect());
         assertFalse(domain.isSynced());
-        assertEquals("Wrong answer", domain.getSelectedAnswer());
+        assertEquals("Wrong answer", domain.getAnswer());
         assertEquals("device-id-unsynced", domain.getDeviceId());
     }
 
@@ -138,7 +138,7 @@ public class ResponseMapperTest {
         // Then
         assertEquals(originalEntity.getId(), resultEntity.getId());
         assertEquals(originalEntity.getQuestionId(), resultEntity.getQuestionId());
-        assertEquals(originalEntity.getSelectedAnswer(), resultEntity.getSelectedAnswer());
+        assertEquals(originalEntity.getAnswer(), resultEntity.getAnswer());
         assertEquals(originalEntity.isCorrect(), resultEntity.isCorrect());
         assertEquals(originalEntity.getTimestamp(), resultEntity.getTimestamp());
         assertEquals(originalEntity.isSynced(), resultEntity.isSynced());
@@ -165,7 +165,7 @@ public class ResponseMapperTest {
         // Then
         assertEquals(originalDomain.getId(), resultDomain.getId());
         assertEquals(originalDomain.getQuestionId(), resultDomain.getQuestionId());
-        assertEquals(originalDomain.getSelectedAnswer(), resultDomain.getSelectedAnswer());
+        assertEquals(originalDomain.getAnswer(), resultDomain.getAnswer());
         assertEquals(originalDomain.isCorrect(), resultDomain.isCorrect());
         assertEquals(originalDomain.getTimestamp(), resultDomain.getTimestamp());
         assertEquals(originalDomain.isSynced(), resultDomain.isSynced());

--- a/android/app/src/test/java/com/manuscripta/student/domain/model/ResponseTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/domain/model/ResponseTest.java
@@ -34,7 +34,7 @@ public class ResponseTest {
         assertNotNull(response);
         assertEquals("response-id", response.getId());
         assertEquals("question-id", response.getQuestionId());
-        assertEquals("Answer B", response.getSelectedAnswer());
+        assertEquals("Answer B", response.getAnswer());
         assertTrue(response.isCorrect());
         assertEquals(1234567890L, response.getTimestamp());
         assertFalse(response.isSynced());
@@ -49,7 +49,7 @@ public class ResponseTest {
         assertNotNull(newResponse.getId());
         assertFalse(newResponse.getId().isEmpty());
         assertEquals("q-123", newResponse.getQuestionId());
-        assertEquals("Answer A", newResponse.getSelectedAnswer());
+        assertEquals("Answer A", newResponse.getAnswer());
         assertFalse(newResponse.isCorrect());
         assertTrue(newResponse.getTimestamp() > 0);
         assertFalse(newResponse.isSynced());
@@ -76,7 +76,7 @@ public class ResponseTest {
                 true,
                 "device-empty-ans"
         );
-        assertEquals("", r.getSelectedAnswer());
+        assertEquals("", r.getAnswer());
     }
 
     @Test
@@ -197,7 +197,7 @@ public class ResponseTest {
     }
 
     @Test
-    public void testConstructor_nullSelectedAnswer_throwsException() {
+    public void testConstructor_nullAnswer_throwsException() {
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> new Response(
@@ -210,7 +210,7 @@ public class ResponseTest {
                         "device-null-ans"
                 )
         );
-        assertEquals("Response selectedAnswer cannot be null", exception.getMessage());
+        assertEquals("Response answer cannot be null", exception.getMessage());
     }
 
     @Test
@@ -258,19 +258,19 @@ public class ResponseTest {
     }
 
     @Test
-    public void testCreate_nullSelectedAnswer_throwsException() {
+    public void testCreate_nullAnswer_throwsException() {
         IllegalArgumentException exception = assertThrows(
                 IllegalArgumentException.class,
                 () -> Response.create("q-id", null, "device-create-null-ans")
         );
-        assertEquals("Response selectedAnswer cannot be null", exception.getMessage());
+        assertEquals("Response answer cannot be null", exception.getMessage());
     }
 
     @Test
     public void testCreateFactoryMethodWithEmptyAnswer() {
         // Empty answer is valid for create
         Response r = Response.create("q-id", "", "device-empty-create-ans");
-        assertEquals("", r.getSelectedAnswer());
+        assertEquals("", r.getAnswer());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Renamed `selectedAnswer` field to `answer` in `ResponseEntity` (data layer)
- Renamed `selectedAnswer` field to `answer` in `Response` domain model
- Updated `ResponseMapper` to use the new getter name
- Updated all related unit tests and error messages

## Related Issue
Closes #44

## Files Changed
- `ResponseEntity.java` - field and getter renamed
- `Response.java` - field, getter, factory method, and constructor updated
- `ResponseMapper.java` - updated to use `getAnswer()`
- `ResponseEntityTest.java` - assertions updated
- `ResponseTest.java` - assertions and test method names updated
- `ResponseMapperTest.java` - assertions updated
- `ResponseDaoTest.java` - assertions updated

## Test plan
- [x] All existing unit tests pass with renamed field
- [x] No breaking changes to external APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)