### PR TITLE
[DOCS] Define pairing process specification and update API contract

### DIFF
--- a/docs/API Contract.md
+++ b/docs/API Contract.md
@@ -48,28 +48,37 @@ The teacher laptop broadcasts its presence on the local network using UDP, allow
    - Teacher IP address
    - HTTP port
    - TCP port
-   - Session identifier
 
 2. **Student Discovery:** Student tablets listen for UDP broadcast messages on the same port. Upon receiving a broadcast, they:
    - Extract the teacher's IP address and port information
    - Initiate HTTP and TCP connections using the discovered information
-   - Complete the pairing handshake on both channels
+   - Complete the pairing handshake on both channels, as specified in `Pairing Process.md` §2
 
-**Broadcast Message Format:**
-```json
-{
-  "type": "DISCOVERY",
-  "teacherIp": "192.168.1.100",
-  "httpPort": 5911,
-  "tcpPort": 5912,
-  "sessionId": "session-uuid",
-  "timestamp": "2023-10-27T10:00:00Z"
-}
+**Broadcast Message Format (Binary):**
+
+UDP discovery messages use the same opcode-operand binary format as TCP messages for consistency and efficiency.
+
+| Field | Offset | Size | Description |
+|-------|--------|------|-------------|
+| Opcode | 0 | 1 byte | `0x00` = DISCOVERY |
+| IP Address | 1 | 4 bytes | IPv4 address (network byte order, big-endian) |
+| HTTP Port | 5 | 2 bytes | Unsigned, little-endian |
+| TCP Port | 7 | 2 bytes | Unsigned, little-endian |
+
+**Total message size:** 9 bytes
+
+**Example: Discovery Message for 192.168.1.100, HTTP 5911, TCP 5912**
+```
+Byte 0:      0x00                         (DISCOVERY opcode)
+Bytes 1-4:   0xC0 0xA8 0x01 0x64          (192.168.1.100)
+Bytes 5-6:   0x17 0x17                    (5911 little-endian)
+Bytes 7-8:   0x18 0x17                    (5912 little-endian)
 ```
 
 **Notes:**
 - The teacher application should broadcast discovery messages at regular intervals (3 seconds).
-- Student tablets should verify the session identifier to ensure they're connecting to the correct teacher session.
+- IP address uses network byte order (big-endian) as per standard networking conventions.
+- Ports use little-endian to maintain consistency with TCP message operands.
 
 ---
 
@@ -149,6 +158,24 @@ Tablet configuration is an object associated with lesson materials but handled s
 
 Students submit their work to the teacher.
 
+### 2.4. Device Pairing (Client -> Server)
+
+Used during the pairing handshake to register a student device with the teacher server. See `Pairing Process.md` §2 for the full pairing sequence.
+
+#### Register Device
+-   **Endpoint:** `POST /pair`
+-   **Body:**
+    ```json
+    {
+      "deviceId": "device-uuid-generated-by-client"
+    }
+    ```
+-   **Response:** `201 Created`
+    ```json
+    {} // Empty 201 to confirm successful pairing
+    ```
+-   **Error Response:** `409 Conflict` (if deviceId is already paired)
+
 #### Submit Response
 Submits a single answer to a question.
 
@@ -184,34 +211,73 @@ Submits multiple responses at once (e.g., when reconnecting after offline mode).
 
 ---
 
-## 3. TCP Protocol (Real-time Control)
+## 3. Binary Protocol (TCP & UDP)
 
-Used for low-latency control signals that require immediate transmission. TCP messages use a **binary protocol** with opcode-based message structure.
+Both TCP and UDP use a unified **binary protocol** with opcode-based message structure for consistency and efficiency.
 
-### 3.1. TCP Message Structure
+### 3.1. Message Structure
 
-Each TCP message consists of:
-1. **Opcode** (1 byte, unsigned, little-endian): Identifies the message type
+Each binary message consists of:
+1. **Opcode** (1 byte, unsigned): Identifies the message type
 2. **Operand** (variable length, optional): Custom data associated with the message type
 
 The length and encoding/decoding of the operand depends on the specific opcode.
 
+### 3.2. Opcode Registry
+
+| Range | Purpose |
+|-------|---------|
+| `0x00` | UDP Discovery |
+| `0x01` - `0x0F` | Server → Client Control (TCP) |
+| `0x10` - `0x1F` | Client → Server Status (TCP) |
+| `0x20` - `0x2F` | Pairing (TCP) |
+
+### 3.3. UDP Messages
+
+#### Server Broadcast
+
+| Opcode | Name | Operand | Description |
+|--------|------|---------|-------------|
+| `0x00` | DISCOVERY | IP (4 bytes) + HTTP port (2 bytes) + TCP port (2 bytes) | Broadcasts server presence |
+
+See §1.1 for detailed format.
+
+### 3.4. TCP Control Messages (Server → Client)
+
+| Opcode | Name | Operand | Description |
 |--------|------|---------|-------------|
 | `0x01` | LOCK_SCREEN | None | Locks the student's screen |
 | `0x02` | UNLOCK_SCREEN | None | Unlocks the student's screen |
 | `0x03` | REFRESH_CONFIG | None | Triggers tablet to re-fetch configuration via HTTP |
 
-**Example: Lock Screen Message**
+### 3.5. TCP Pairing Messages
+
+Used during the pairing handshake to establish TCP connectivity. See `Pairing Process.md` §2 for the full pairing sequence.
+
+#### Client → Server Pairing Request
+
+| Opcode | Name | Operand | Description |
+|--------|------|---------|-------------|
+| `0x20` | PAIRING_REQUEST | Device ID (UTF-8 string) | Client requests pairing with server |
+
+**Example: Pairing Request Message**
 ```
-Byte 0: 0x01 (LOCK_SCREEN opcode)
+Byte 0: 0x20 (PAIRING_REQUEST opcode)
+Bytes 1-N: "device-uuid" (UTF-8 encoded device ID)
 ```
 
-**Example: Unlock Screen Message**
+#### Server → Client Pairing Acknowledgement
+
+| Opcode | Name | Operand | Description |
+|--------|------|---------|-------------|
+| `0x21` | PAIRING_ACK | None | Server acknowledges successful TCP pairing |
+
+**Example: Pairing Acknowledgement Message**
 ```
-Byte 0: 0x02 (UNLOCK_SCREEN opcode)
+Byte 0: 0x21 (PAIRING_ACK opcode)
 ```
 
-#### Client → Server Status Updates
+### 3.6. TCP Status Messages (Client → Server)
 
 | Opcode | Name | Operand | Description |
 |--------|------|---------|-------------|
@@ -241,7 +307,7 @@ Byte 0: 0x11 (HAND_RAISED opcode)
 Bytes 1-N: "device-123" (UTF-8 encoded device ID)
 ```
 
-### 3.3. Extensibility
+### 3.7. Extensibility
 
 Additional opcodes can be defined as needed. Both applications should:
 - Maintain a registry of opcode definitions

--- a/docs/Pairing Process.md
+++ b/docs/Pairing Process.md
@@ -1,0 +1,52 @@
+# Pairing Process Specification
+
+This document defines the pairing process between the Windows device and the Android devices.
+
+## Section 1: General Principles
+
+(1) In this document, "paired" means —
+    (a) The Windows device has recorded the Android device's deviceId.
+    (b) The Android device has recorded the Windows device's IP address, HTTP port, and TCP port.
+    (c) Successful bi-directional message interchange using both TCP and HTTP has been proven, as specified in Section 2.
+
+(2) The pairing phase must ensure that:
+
+    (a) The Android devices successfully discover the Windows device.
+    (b) The Windows device successfully records paired Android devices.
+    (c) Successful bi-directional message interchange using both TCP and HTTP REST APIs have been proven successful.
+
+(3) Requests received from unpaired Android devices should be rejected. 
+
+(4) Pairing phases, as defined in Section 2, must be conducted sequentially. If any pairing phases were deemed unsuccessful, the pairing process must start over.
+
+(5) This document has authority over the general API contract. In the case of any conflicts or contradiction to that contract, that contract should be amended to reflect specifications in this document. 
+
+(6) This document may be cited as "Pairing Process Specification".
+
+## Section 2: Pairing Phases
+
+(1) The Windows device should initiate a pairing process by broadcasting a UDP discovery message, as specified in `API Contract.md` §1.1, on the UDP port specified therein. This message must, as a minimum, include the following information:
+    (a) The IP address of the Windows Device.
+    (b) The HTTP port to be used.
+    (c) The TCP port to be used.
+
+(2) The Android device, on discovery of a message as specified in (1), must:
+    (a) Extract the IP address and ports in that message.
+    (b) Establish a TCP connection to the Windows device and send a `PAIRING_REQUEST` message (opcode `0x20`), as specified in `API Contract.md` §3.2. This message must contain the deviceId that the Android device generates.
+    (c) Make a POST request to the `/pair` endpoint, as specified in `API Contract.md` §2.4, with a body containing the deviceId.
+
+(3) The Windows device should respond to the messages defined in (2) to signal correct message transmission in that channel:
+    (a) On receipt of a message specified in (2)(b), respond with a `PAIRING_ACK` message (opcode `0x21`), as specified in `API Contract.md` §3.2, which indicates that message transmission through TCP was successful.
+    (b) Respond to the POST request, specified in (2)(c), with a `201 Created` response, as specified in `API Contract.md` §2.4, which indicates that message transmission was successful.
+
+(4) The Windows device should, on completion of (1)-(3) above, for all purposes, deem that Android device as paired, such that requests from that Android device would now be accepted. The Windows device must store the deviceId received during pairing.
+
+(5) The Android device should, on receipt of both messages specified in (3)(a) and (3)(b), deem its pairing with the Windows device as successful. The Android device must store the Windows device's IP address, HTTP port, and TCP port.
+
+## Appendix 1 - Maintaining this document (Instructions to AI Agents)
+
+(1) An AI agent, when instructed to review or edit this document, shall —
+    (a) Cross-reference `API Contract.md`, and replace any implementation details that are in contradiction to this document.
+    (b) Where required, fill in detailed message structures of messages in that document, and insert appropriate cross-references in this document. "(?)" in this document shall mean that the implementation details shall be provided.
+
+(2) The AI agent shall seek for clarification from the human rather than making assumptions, if it deems any clauses in the documents involved unclear.


### PR DESCRIPTION
Formalised Pairing Processes and Updated API Contract Accordingly.

- Add Pairing Process.md with formal specification of device pairing
- Define 'paired' state requirements (deviceId, IP/ports, bidirectional comms)
- Add TCP pairing opcodes (0x20 PAIRING_REQUEST, 0x21 PAIRING_ACK)
- Add HTTP pairing endpoint (POST /pair)
- Replace JSON UDP broadcast with binary opcode-operand format (9 bytes)
- Remove sessionId from discovery messages
- Restructure binary protocol section to cover both TCP and UDP
- Add opcode registry with reserved ranges