### PR TITLE
[Android] Add TCP message encoder and decoder

### DIFF
--- a/android/app/src/main/java/com/manuscripta/student/network/tcp/TcpMessageDecoder.java
+++ b/android/app/src/main/java/com/manuscripta/student/network/tcp/TcpMessageDecoder.java
@@ -1,0 +1,153 @@
+package com.manuscripta.student.network.tcp;
+
+import androidx.annotation.NonNull;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Decoder for TCP messages.
+ * Deserialises byte arrays to {@link TcpMessage} objects according to the binary protocol format.
+ *
+ * <p>Protocol format:
+ * <pre>
+ * [1 byte: opcode][N bytes: operand]
+ * </pre>
+ *
+ * <p>The opcode is always 1 byte. The operand length varies by message type and may be empty.
+ */
+@Singleton
+public final class TcpMessageDecoder {
+
+    /**
+     * Creates a new TcpMessageDecoder.
+     */
+    @Inject
+    public TcpMessageDecoder() {
+        // Empty constructor for Hilt injection
+    }
+
+    /**
+     * Decodes a byte array to a TCP message.
+     *
+     * <p>The first byte is interpreted as the opcode, and any remaining bytes
+     * are treated as the operand payload.
+     *
+     * @param data The byte array to decode.
+     * @return The decoded message.
+     * @throws TcpProtocolException If the data is null, empty, or contains an unknown opcode.
+     */
+    @NonNull
+    public TcpMessage decode(@NonNull byte[] data) throws TcpProtocolException {
+        if (data == null || data.length == 0) {
+            throw new TcpProtocolException(
+                    TcpProtocolException.ErrorType.EMPTY_DATA,
+                    "Cannot decode null or empty data");
+        }
+
+        byte opcodeValue = data[0];
+        TcpOpcode opcode = TcpOpcode.fromValue(opcodeValue);
+
+        if (opcode == null) {
+            throw new TcpProtocolException(opcodeValue);
+        }
+
+        // Extract operand (all bytes after the opcode)
+        byte[] operand = data.length > 1
+                ? Arrays.copyOfRange(data, 1, data.length)
+                : new byte[0];
+
+        return createMessage(opcode, operand);
+    }
+
+    /**
+     * Creates the appropriate message instance based on the opcode.
+     *
+     * @param opcode  The decoded opcode.
+     * @param operand The operand bytes (may be empty).
+     * @return The appropriate TcpMessage subclass instance.
+     * @throws TcpProtocolException If the operand is invalid for the message type.
+     */
+    @NonNull
+    private TcpMessage createMessage(@NonNull TcpOpcode opcode, @NonNull byte[] operand)
+            throws TcpProtocolException {
+        if (opcode == TcpOpcode.LOCK_SCREEN) {
+            return new LockScreenMessage();
+        } else if (opcode == TcpOpcode.UNLOCK_SCREEN) {
+            return new UnlockScreenMessage();
+        } else if (opcode == TcpOpcode.REFRESH_CONFIG) {
+            return new RefreshConfigMessage();
+        } else if (opcode == TcpOpcode.FETCH_MATERIALS) {
+            return new FetchMaterialsMessage();
+        } else if (opcode == TcpOpcode.PAIRING_ACK) {
+            return new PairingAckMessage();
+        } else if (opcode == TcpOpcode.STATUS_UPDATE) {
+            return createStatusUpdateMessage(operand);
+        } else if (opcode == TcpOpcode.HAND_RAISED) {
+            return createHandRaisedMessage(operand);
+        } else {
+            // PAIRING_REQUEST is the only remaining case
+            return createPairingRequestMessage(operand);
+        }
+    }
+
+    /**
+     * Creates a StatusUpdateMessage from the operand.
+     *
+     * @param operand The UTF-8 encoded JSON payload.
+     * @return The StatusUpdateMessage.
+     * @throws TcpProtocolException If the operand is empty.
+     */
+    @NonNull
+    private StatusUpdateMessage createStatusUpdateMessage(@NonNull byte[] operand)
+            throws TcpProtocolException {
+        if (operand.length == 0) {
+            throw new TcpProtocolException(
+                    TcpProtocolException.ErrorType.MALFORMED_DATA,
+                    "STATUS_UPDATE message requires JSON payload");
+        }
+        String jsonPayload = new String(operand, StandardCharsets.UTF_8);
+        return new StatusUpdateMessage(jsonPayload);
+    }
+
+    /**
+     * Creates a HandRaisedMessage from the operand.
+     *
+     * @param operand The UTF-8 encoded device ID.
+     * @return The HandRaisedMessage.
+     * @throws TcpProtocolException If the operand is empty.
+     */
+    @NonNull
+    private HandRaisedMessage createHandRaisedMessage(@NonNull byte[] operand)
+            throws TcpProtocolException {
+        if (operand.length == 0) {
+            throw new TcpProtocolException(
+                    TcpProtocolException.ErrorType.MALFORMED_DATA,
+                    "HAND_RAISED message requires device ID");
+        }
+        String deviceId = new String(operand, StandardCharsets.UTF_8);
+        return new HandRaisedMessage(deviceId);
+    }
+
+    /**
+     * Creates a PairingRequestMessage from the operand.
+     *
+     * @param operand The UTF-8 encoded device ID.
+     * @return The PairingRequestMessage.
+     * @throws TcpProtocolException If the operand is empty.
+     */
+    @NonNull
+    private PairingRequestMessage createPairingRequestMessage(@NonNull byte[] operand)
+            throws TcpProtocolException {
+        if (operand.length == 0) {
+            throw new TcpProtocolException(
+                    TcpProtocolException.ErrorType.MALFORMED_DATA,
+                    "PAIRING_REQUEST message requires device ID");
+        }
+        String deviceId = new String(operand, StandardCharsets.UTF_8);
+        return new PairingRequestMessage(deviceId);
+    }
+}

--- a/android/app/src/main/java/com/manuscripta/student/network/tcp/TcpMessageEncoder.java
+++ b/android/app/src/main/java/com/manuscripta/student/network/tcp/TcpMessageEncoder.java
@@ -1,0 +1,62 @@
+package com.manuscripta.student.network.tcp;
+
+import androidx.annotation.NonNull;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Encoder for TCP messages.
+ * Serialises {@link TcpMessage} objects to byte arrays according to the binary protocol format.
+ *
+ * <p>Protocol format:
+ * <pre>
+ * [1 byte: opcode][N bytes: operand]
+ * </pre>
+ *
+ * <p>The opcode is always 1 byte. The operand length varies by message type and may be empty.
+ */
+@Singleton
+public final class TcpMessageEncoder {
+
+    /**
+     * Creates a new TcpMessageEncoder.
+     */
+    @Inject
+    public TcpMessageEncoder() {
+        // Empty constructor for Hilt injection
+    }
+
+    /**
+     * Encodes a TCP message to a byte array.
+     *
+     * <p>The resulting byte array contains the opcode as the first byte,
+     * followed by the operand bytes (if any).
+     *
+     * @param message The message to encode.
+     * @return The encoded byte array.
+     * @throws TcpProtocolException If the message is null.
+     */
+    @NonNull
+    public byte[] encode(@NonNull TcpMessage message) throws TcpProtocolException {
+        if (message == null) {
+            throw new TcpProtocolException(
+                    TcpProtocolException.ErrorType.NULL_MESSAGE,
+                    "Cannot encode null message");
+        }
+
+        byte[] operand = message.getOperand();
+
+        // For messages with no operand, just return the opcode
+        if (operand.length == 0) {
+            return new byte[]{message.getOpcode().getValue()};
+        }
+
+        // For messages with operand, combine opcode + operand
+        byte[] result = new byte[1 + operand.length];
+        result[0] = message.getOpcode().getValue();
+        System.arraycopy(operand, 0, result, 1, operand.length);
+
+        return result;
+    }
+}

--- a/android/app/src/main/java/com/manuscripta/student/network/tcp/TcpProtocolException.java
+++ b/android/app/src/main/java/com/manuscripta/student/network/tcp/TcpProtocolException.java
@@ -1,0 +1,106 @@
+package com.manuscripta.student.network.tcp;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Exception thrown when there is an error in the TCP protocol.
+ * This includes errors such as unknown opcodes, malformed data,
+ * or invalid message formats.
+ */
+public final class TcpProtocolException extends Exception {
+
+    /**
+     * The type of protocol error that occurred.
+     */
+    private final ErrorType errorType;
+
+    /**
+     * Optional invalid opcode value for unknown opcode errors.
+     */
+    private final Byte invalidOpcode;
+
+    /**
+     * Enumeration of possible protocol error types.
+     */
+    public enum ErrorType {
+        /**
+         * The message data is empty or null.
+         */
+        EMPTY_DATA,
+
+        /**
+         * The opcode byte is not a recognized opcode.
+         */
+        UNKNOWN_OPCODE,
+
+        /**
+         * The message data is malformed or corrupted.
+         */
+        MALFORMED_DATA,
+
+        /**
+         * The message is null.
+         */
+        NULL_MESSAGE
+    }
+
+    /**
+     * Creates a new TcpProtocolException with the specified error type and message.
+     *
+     * @param errorType The type of protocol error.
+     * @param message   A descriptive error message.
+     */
+    public TcpProtocolException(@NonNull ErrorType errorType, @NonNull String message) {
+        super(message);
+        this.errorType = errorType;
+        this.invalidOpcode = null;
+    }
+
+    /**
+     * Creates a new TcpProtocolException for an unknown opcode error.
+     *
+     * @param invalidOpcode The unrecognized opcode value.
+     */
+    public TcpProtocolException(byte invalidOpcode) {
+        super(String.format("Unknown opcode: 0x%02X", invalidOpcode));
+        this.errorType = ErrorType.UNKNOWN_OPCODE;
+        this.invalidOpcode = invalidOpcode;
+    }
+
+    /**
+     * Returns the type of protocol error.
+     *
+     * @return The error type.
+     */
+    @NonNull
+    public ErrorType getErrorType() {
+        return errorType;
+    }
+
+    /**
+     * Returns the invalid opcode value if this is an unknown opcode error.
+     *
+     * @return The invalid opcode, or null if not applicable.
+     */
+    @Nullable
+    public Byte getInvalidOpcode() {
+        return invalidOpcode;
+    }
+
+    /**
+     * Returns a string representation of this exception.
+     *
+     * @return A string containing the error type and message.
+     */
+    @NonNull
+    @Override
+    public String toString() {
+        if (invalidOpcode != null) {
+            return String.format("TcpProtocolException{type=%s, opcode=0x%02X}",
+                    errorType, invalidOpcode);
+        }
+        return String.format("TcpProtocolException{type=%s, message=%s}",
+                errorType, getMessage());
+    }
+}

--- a/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpEncoderDecoderRoundTripTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpEncoderDecoderRoundTripTest.java
@@ -1,0 +1,219 @@
+package com.manuscripta.student.network.tcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Round-trip tests for {@link TcpMessageEncoder} and {@link TcpMessageDecoder}.
+ * These tests verify that encoding then decoding a message produces an equivalent message.
+ */
+public class TcpEncoderDecoderRoundTripTest {
+
+    private TcpMessageEncoder encoder;
+    private TcpMessageDecoder decoder;
+
+    @Before
+    public void setUp() {
+        encoder = new TcpMessageEncoder();
+        decoder = new TcpMessageDecoder();
+    }
+
+    // ========== No-operand message round-trips ==========
+
+    @Test
+    public void roundTrip_lockScreenMessage_preservesMessage() throws TcpProtocolException {
+        LockScreenMessage original = new LockScreenMessage();
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof LockScreenMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+    }
+
+    @Test
+    public void roundTrip_unlockScreenMessage_preservesMessage() throws TcpProtocolException {
+        UnlockScreenMessage original = new UnlockScreenMessage();
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof UnlockScreenMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+    }
+
+    @Test
+    public void roundTrip_refreshConfigMessage_preservesMessage() throws TcpProtocolException {
+        RefreshConfigMessage original = new RefreshConfigMessage();
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof RefreshConfigMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+    }
+
+    @Test
+    public void roundTrip_fetchMaterialsMessage_preservesMessage() throws TcpProtocolException {
+        FetchMaterialsMessage original = new FetchMaterialsMessage();
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof FetchMaterialsMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+    }
+
+    @Test
+    public void roundTrip_pairingAckMessage_preservesMessage() throws TcpProtocolException {
+        PairingAckMessage original = new PairingAckMessage();
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof PairingAckMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+    }
+
+    // ========== Operand message round-trips ==========
+
+    @Test
+    public void roundTrip_statusUpdateMessage_preservesPayload() throws TcpProtocolException {
+        String json = "{\"status\":\"ACTIVE\",\"battery\":75}";
+        StatusUpdateMessage original = new StatusUpdateMessage(json);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof StatusUpdateMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+        assertEquals(json, ((StatusUpdateMessage) decoded).getJsonPayload());
+    }
+
+    @Test
+    public void roundTrip_handRaisedMessage_preservesDeviceId() throws TcpProtocolException {
+        String deviceId = "device-abc-123-xyz";
+        HandRaisedMessage original = new HandRaisedMessage(deviceId);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof HandRaisedMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+        assertEquals(deviceId, ((HandRaisedMessage) decoded).getDeviceId());
+    }
+
+    @Test
+    public void roundTrip_pairingRequestMessage_preservesDeviceId() throws TcpProtocolException {
+        String deviceId = "tablet-789-xyz-456";
+        PairingRequestMessage original = new PairingRequestMessage(deviceId);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof PairingRequestMessage);
+        assertEquals(original.getOpcode(), decoded.getOpcode());
+        assertEquals(deviceId, ((PairingRequestMessage) decoded).getDeviceId());
+    }
+
+    // ========== Unicode round-trips ==========
+
+    @Test
+    public void roundTrip_statusUpdate_preservesUnicodePayload() throws TcpProtocolException {
+        String json = "{\"message\":\"こんにちは世界\",\"emoji\":\"🎉🚀\"}";
+        StatusUpdateMessage original = new StatusUpdateMessage(json);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof StatusUpdateMessage);
+        assertEquals(json, ((StatusUpdateMessage) decoded).getJsonPayload());
+    }
+
+    @Test
+    public void roundTrip_handRaised_preservesUnicodeDeviceId() throws TcpProtocolException {
+        String deviceId = "device-日本語-🔥";
+        HandRaisedMessage original = new HandRaisedMessage(deviceId);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof HandRaisedMessage);
+        assertEquals(deviceId, ((HandRaisedMessage) decoded).getDeviceId());
+    }
+
+    @Test
+    public void roundTrip_pairingRequest_preservesUnicodeDeviceId() throws TcpProtocolException {
+        String deviceId = "tablet-émoji-🎮";
+        PairingRequestMessage original = new PairingRequestMessage(deviceId);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof PairingRequestMessage);
+        assertEquals(deviceId, ((PairingRequestMessage) decoded).getDeviceId());
+    }
+
+    // ========== Large payload round-trips ==========
+
+    @Test
+    public void roundTrip_statusUpdate_preservesLargePayload() throws TcpProtocolException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"data\":\"");
+        for (int i = 0; i < 5000; i++) {
+            sb.append("x");
+        }
+        sb.append("\"}");
+        String json = sb.toString();
+        StatusUpdateMessage original = new StatusUpdateMessage(json);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof StatusUpdateMessage);
+        assertEquals(json, ((StatusUpdateMessage) decoded).getJsonPayload());
+    }
+
+    // ========== Complex JSON round-trips ==========
+
+    @Test
+    public void roundTrip_statusUpdate_preservesComplexJson() throws TcpProtocolException {
+        String json = "{\"deviceId\":\"abc-123\",\"status\":\"ON_TASK\","
+                + "\"battery\":85,\"connected\":true,\"timestamp\":1702200000,"
+                + "\"metadata\":{\"version\":\"1.0\",\"tags\":[\"test\",\"dev\"]}}";
+        StatusUpdateMessage original = new StatusUpdateMessage(json);
+
+        byte[] encoded = encoder.encode(original);
+        TcpMessage decoded = decoder.decode(encoded);
+
+        assertTrue(decoded instanceof StatusUpdateMessage);
+        assertEquals(json, ((StatusUpdateMessage) decoded).getJsonPayload());
+    }
+
+    // ========== All message types ==========
+
+    @Test
+    public void roundTrip_allMessageTypes_succeed() throws TcpProtocolException {
+        TcpMessage[] messages = {
+                new LockScreenMessage(),
+                new UnlockScreenMessage(),
+                new RefreshConfigMessage(),
+                new FetchMaterialsMessage(),
+                new PairingAckMessage(),
+                new StatusUpdateMessage("{\"test\":true}"),
+                new HandRaisedMessage("device-id"),
+                new PairingRequestMessage("device-id")
+        };
+
+        for (TcpMessage original : messages) {
+            byte[] encoded = encoder.encode(original);
+            TcpMessage decoded = decoder.decode(encoded);
+
+            assertEquals(original.getOpcode(), decoded.getOpcode());
+            assertEquals(original.getClass(), decoded.getClass());
+        }
+    }
+}

--- a/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpMessageDecoderTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpMessageDecoderTest.java
@@ -1,0 +1,268 @@
+package com.manuscripta.student.network.tcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Unit tests for {@link TcpMessageDecoder}.
+ */
+public class TcpMessageDecoderTest {
+
+    private TcpMessageDecoder decoder;
+
+    @Before
+    public void setUp() {
+        decoder = new TcpMessageDecoder();
+    }
+
+    // ========== No-operand message tests ==========
+
+    @Test
+    public void decode_lockScreenOpcode_returnsLockScreenMessage() throws TcpProtocolException {
+        byte[] data = {(byte) 0x01};
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof LockScreenMessage);
+        assertEquals(TcpOpcode.LOCK_SCREEN, result.getOpcode());
+    }
+
+    @Test
+    public void decode_unlockScreenOpcode_returnsUnlockScreenMessage() throws TcpProtocolException {
+        byte[] data = {(byte) 0x02};
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof UnlockScreenMessage);
+        assertEquals(TcpOpcode.UNLOCK_SCREEN, result.getOpcode());
+    }
+
+    @Test
+    public void decode_refreshConfigOpcode_returnsRefreshConfigMessage() throws TcpProtocolException {
+        byte[] data = {(byte) 0x03};
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof RefreshConfigMessage);
+        assertEquals(TcpOpcode.REFRESH_CONFIG, result.getOpcode());
+    }
+
+    @Test
+    public void decode_fetchMaterialsOpcode_returnsFetchMaterialsMessage() throws TcpProtocolException {
+        byte[] data = {(byte) 0x04};
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof FetchMaterialsMessage);
+        assertEquals(TcpOpcode.FETCH_MATERIALS, result.getOpcode());
+    }
+
+    @Test
+    public void decode_pairingAckOpcode_returnsPairingAckMessage() throws TcpProtocolException {
+        byte[] data = {(byte) 0x21};
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof PairingAckMessage);
+        assertEquals(TcpOpcode.PAIRING_ACK, result.getOpcode());
+    }
+
+    // ========== Operand message tests ==========
+
+    @Test
+    public void decode_statusUpdateOpcode_returnsStatusUpdateMessage() throws TcpProtocolException {
+        String json = "{\"status\":\"ACTIVE\"}";
+        byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[1 + jsonBytes.length];
+        data[0] = (byte) 0x10;
+        System.arraycopy(jsonBytes, 0, data, 1, jsonBytes.length);
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof StatusUpdateMessage);
+        assertEquals(TcpOpcode.STATUS_UPDATE, result.getOpcode());
+        assertEquals(json, ((StatusUpdateMessage) result).getJsonPayload());
+    }
+
+    @Test
+    public void decode_handRaisedOpcode_returnsHandRaisedMessage() throws TcpProtocolException {
+        String deviceId = "device-abc-123";
+        byte[] idBytes = deviceId.getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[1 + idBytes.length];
+        data[0] = (byte) 0x11;
+        System.arraycopy(idBytes, 0, data, 1, idBytes.length);
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof HandRaisedMessage);
+        assertEquals(TcpOpcode.HAND_RAISED, result.getOpcode());
+        assertEquals(deviceId, ((HandRaisedMessage) result).getDeviceId());
+    }
+
+    @Test
+    public void decode_pairingRequestOpcode_returnsPairingRequestMessage() throws TcpProtocolException {
+        String deviceId = "tablet-xyz-789";
+        byte[] idBytes = deviceId.getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[1 + idBytes.length];
+        data[0] = (byte) 0x20;
+        System.arraycopy(idBytes, 0, data, 1, idBytes.length);
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof PairingRequestMessage);
+        assertEquals(TcpOpcode.PAIRING_REQUEST, result.getOpcode());
+        assertEquals(deviceId, ((PairingRequestMessage) result).getDeviceId());
+    }
+
+    // ========== Unicode and special character tests ==========
+
+    @Test
+    public void decode_statusUpdate_handlesUnicodeCharacters() throws TcpProtocolException {
+        String json = "{\"name\":\"日本語テスト\"}";
+        byte[] jsonBytes = json.getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[1 + jsonBytes.length];
+        data[0] = (byte) 0x10;
+        System.arraycopy(jsonBytes, 0, data, 1, jsonBytes.length);
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof StatusUpdateMessage);
+        assertEquals(json, ((StatusUpdateMessage) result).getJsonPayload());
+    }
+
+    @Test
+    public void decode_handRaised_handlesSpecialCharacters() throws TcpProtocolException {
+        String deviceId = "device-émoji-🎉";
+        byte[] idBytes = deviceId.getBytes(StandardCharsets.UTF_8);
+        byte[] data = new byte[1 + idBytes.length];
+        data[0] = (byte) 0x11;
+        System.arraycopy(idBytes, 0, data, 1, idBytes.length);
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof HandRaisedMessage);
+        assertEquals(deviceId, ((HandRaisedMessage) result).getDeviceId());
+    }
+
+    // ========== No-operand messages with extra bytes ==========
+
+    @Test
+    public void decode_lockScreenWithExtraBytes_ignoresExtraBytes() throws TcpProtocolException {
+        byte[] data = {(byte) 0x01, 0x00, 0x00, 0x00};
+
+        TcpMessage result = decoder.decode(data);
+
+        assertTrue(result instanceof LockScreenMessage);
+    }
+
+    // ========== Error handling tests ==========
+
+    @Test
+    public void decode_nullData_throwsTcpProtocolException() {
+        try {
+            decoder.decode(null);
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.EMPTY_DATA, e.getErrorType());
+        }
+    }
+
+    @Test
+    public void decode_emptyData_throwsTcpProtocolException() {
+        try {
+            decoder.decode(new byte[0]);
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.EMPTY_DATA, e.getErrorType());
+        }
+    }
+
+    @Test
+    public void decode_unknownOpcode_throwsTcpProtocolException() {
+        try {
+            decoder.decode(new byte[]{(byte) 0xFF});
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.UNKNOWN_OPCODE, e.getErrorType());
+            assertNotNull(e.getInvalidOpcode());
+            assertEquals((byte) 0xFF, e.getInvalidOpcode().byteValue());
+        }
+    }
+
+    @Test
+    public void decode_unknownOpcodeZero_throwsTcpProtocolException() {
+        try {
+            decoder.decode(new byte[]{(byte) 0x00});
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.UNKNOWN_OPCODE, e.getErrorType());
+        }
+    }
+
+    @Test
+    public void decode_statusUpdateWithoutPayload_throwsTcpProtocolException() {
+        try {
+            decoder.decode(new byte[]{(byte) 0x10});
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.MALFORMED_DATA, e.getErrorType());
+        }
+    }
+
+    @Test
+    public void decode_handRaisedWithoutPayload_throwsTcpProtocolException() {
+        try {
+            decoder.decode(new byte[]{(byte) 0x11});
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.MALFORMED_DATA, e.getErrorType());
+        }
+    }
+
+    @Test
+    public void decode_pairingRequestWithoutPayload_throwsTcpProtocolException() {
+        try {
+            decoder.decode(new byte[]{(byte) 0x20});
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.MALFORMED_DATA, e.getErrorType());
+        }
+    }
+
+    // ========== Constructor test ==========
+
+    @Test
+    public void constructor_createsInstance() {
+        TcpMessageDecoder decoder = new TcpMessageDecoder();
+        assertNotNull(decoder);
+    }
+
+    // ========== All opcodes test ==========
+
+    @Test
+    public void decode_allValidOpcodes_returnsCorrectMessageTypes() throws TcpProtocolException {
+        // No-operand messages
+        assertTrue(decoder.decode(new byte[]{0x01}) instanceof LockScreenMessage);
+        assertTrue(decoder.decode(new byte[]{0x02}) instanceof UnlockScreenMessage);
+        assertTrue(decoder.decode(new byte[]{0x03}) instanceof RefreshConfigMessage);
+        assertTrue(decoder.decode(new byte[]{0x04}) instanceof FetchMaterialsMessage);
+        assertTrue(decoder.decode(new byte[]{0x21}) instanceof PairingAckMessage);
+
+        // Messages with operand
+        byte[] statusBytes = new byte[]{0x10, '{', '}'};
+        assertTrue(decoder.decode(statusBytes) instanceof StatusUpdateMessage);
+
+        byte[] handBytes = new byte[]{0x11, 'i', 'd'};
+        assertTrue(decoder.decode(handBytes) instanceof HandRaisedMessage);
+
+        byte[] pairBytes = new byte[]{0x20, 'i', 'd'};
+        assertTrue(decoder.decode(pairBytes) instanceof PairingRequestMessage);
+    }
+}

--- a/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpMessageEncoderTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpMessageEncoderTest.java
@@ -1,0 +1,229 @@
+package com.manuscripta.student.network.tcp;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Unit tests for {@link TcpMessageEncoder}.
+ */
+public class TcpMessageEncoderTest {
+
+    private TcpMessageEncoder encoder;
+
+    @Before
+    public void setUp() {
+        encoder = new TcpMessageEncoder();
+    }
+
+    // ========== No-operand message tests ==========
+
+    @Test
+    public void encode_lockScreenMessage_returnsOpcodeOnly() throws TcpProtocolException {
+        LockScreenMessage message = new LockScreenMessage();
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1, result.length);
+        assertEquals((byte) 0x01, result[0]);
+    }
+
+    @Test
+    public void encode_unlockScreenMessage_returnsOpcodeOnly() throws TcpProtocolException {
+        UnlockScreenMessage message = new UnlockScreenMessage();
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1, result.length);
+        assertEquals((byte) 0x02, result[0]);
+    }
+
+    @Test
+    public void encode_refreshConfigMessage_returnsOpcodeOnly() throws TcpProtocolException {
+        RefreshConfigMessage message = new RefreshConfigMessage();
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1, result.length);
+        assertEquals((byte) 0x03, result[0]);
+    }
+
+    @Test
+    public void encode_fetchMaterialsMessage_returnsOpcodeOnly() throws TcpProtocolException {
+        FetchMaterialsMessage message = new FetchMaterialsMessage();
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1, result.length);
+        assertEquals((byte) 0x04, result[0]);
+    }
+
+    @Test
+    public void encode_pairingAckMessage_returnsOpcodeOnly() throws TcpProtocolException {
+        PairingAckMessage message = new PairingAckMessage();
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1, result.length);
+        assertEquals((byte) 0x21, result[0]);
+    }
+
+    // ========== Operand message tests ==========
+
+    @Test
+    public void encode_statusUpdateMessage_returnsOpcodeAndJsonPayload() throws TcpProtocolException {
+        String json = "{\"status\":\"ACTIVE\"}";
+        StatusUpdateMessage message = new StatusUpdateMessage(json);
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1 + json.getBytes(StandardCharsets.UTF_8).length, result.length);
+        assertEquals((byte) 0x10, result[0]);
+
+        byte[] payload = new byte[result.length - 1];
+        System.arraycopy(result, 1, payload, 0, payload.length);
+        assertEquals(json, new String(payload, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void encode_handRaisedMessage_returnsOpcodeAndDeviceId() throws TcpProtocolException {
+        String deviceId = "device-abc-123";
+        HandRaisedMessage message = new HandRaisedMessage(deviceId);
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1 + deviceId.getBytes(StandardCharsets.UTF_8).length, result.length);
+        assertEquals((byte) 0x11, result[0]);
+
+        byte[] payload = new byte[result.length - 1];
+        System.arraycopy(result, 1, payload, 0, payload.length);
+        assertEquals(deviceId, new String(payload, StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void encode_pairingRequestMessage_returnsOpcodeAndDeviceId() throws TcpProtocolException {
+        String deviceId = "tablet-xyz-789";
+        PairingRequestMessage message = new PairingRequestMessage(deviceId);
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1 + deviceId.getBytes(StandardCharsets.UTF_8).length, result.length);
+        assertEquals((byte) 0x20, result[0]);
+
+        byte[] payload = new byte[result.length - 1];
+        System.arraycopy(result, 1, payload, 0, payload.length);
+        assertEquals(deviceId, new String(payload, StandardCharsets.UTF_8));
+    }
+
+    // ========== Unicode and special character tests ==========
+
+    @Test
+    public void encode_statusUpdateMessage_handlesUnicodeCharacters() throws TcpProtocolException {
+        String json = "{\"name\":\"日本語テスト\"}";
+        StatusUpdateMessage message = new StatusUpdateMessage(json);
+
+        byte[] result = encoder.encode(message);
+        byte[] expectedPayload = json.getBytes(StandardCharsets.UTF_8);
+
+        assertEquals(1 + expectedPayload.length, result.length);
+        assertEquals((byte) 0x10, result[0]);
+
+        byte[] actualPayload = new byte[result.length - 1];
+        System.arraycopy(result, 1, actualPayload, 0, actualPayload.length);
+        assertArrayEquals(expectedPayload, actualPayload);
+    }
+
+    @Test
+    public void encode_handRaisedMessage_handlesSpecialCharacters() throws TcpProtocolException {
+        String deviceId = "device-émoji-🎉";
+        HandRaisedMessage message = new HandRaisedMessage(deviceId);
+
+        byte[] result = encoder.encode(message);
+        byte[] expectedPayload = deviceId.getBytes(StandardCharsets.UTF_8);
+
+        assertEquals(1 + expectedPayload.length, result.length);
+
+        byte[] actualPayload = new byte[result.length - 1];
+        System.arraycopy(result, 1, actualPayload, 0, actualPayload.length);
+        assertEquals(deviceId, new String(actualPayload, StandardCharsets.UTF_8));
+    }
+
+    // ========== Edge case tests ==========
+
+    @Test
+    public void encode_statusUpdateMessage_handlesEmptyJson() throws TcpProtocolException {
+        String json = "";
+        StatusUpdateMessage message = new StatusUpdateMessage(json);
+
+        byte[] result = encoder.encode(message);
+
+        // Empty string results in opcode only
+        assertEquals(1, result.length);
+        assertEquals((byte) 0x10, result[0]);
+    }
+
+    @Test
+    public void encode_statusUpdateMessage_handlesLargePayload() throws TcpProtocolException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"data\":\"");
+        for (int i = 0; i < 10000; i++) {
+            sb.append("x");
+        }
+        sb.append("\"}");
+        String json = sb.toString();
+        StatusUpdateMessage message = new StatusUpdateMessage(json);
+
+        byte[] result = encoder.encode(message);
+
+        assertEquals(1 + json.getBytes(StandardCharsets.UTF_8).length, result.length);
+        assertEquals((byte) 0x10, result[0]);
+    }
+
+    // ========== Error handling tests ==========
+
+    @Test
+    public void encode_nullMessage_throwsTcpProtocolException() {
+        try {
+            encoder.encode(null);
+            fail("Expected TcpProtocolException");
+        } catch (TcpProtocolException e) {
+            assertEquals(TcpProtocolException.ErrorType.NULL_MESSAGE, e.getErrorType());
+        }
+    }
+
+    // ========== Constructor test ==========
+
+    @Test
+    public void constructor_createsInstance() {
+        TcpMessageEncoder encoder = new TcpMessageEncoder();
+        assertNotNull(encoder);
+    }
+
+    // ========== Round-trip preparation tests ==========
+
+    @Test
+    public void encode_allMessageTypes_producesNonEmptyResult() throws TcpProtocolException {
+        TcpMessage[] messages = {
+                new LockScreenMessage(),
+                new UnlockScreenMessage(),
+                new RefreshConfigMessage(),
+                new FetchMaterialsMessage(),
+                new PairingAckMessage(),
+                new StatusUpdateMessage("{\"test\":true}"),
+                new HandRaisedMessage("device-id"),
+                new PairingRequestMessage("device-id")
+        };
+
+        for (TcpMessage message : messages) {
+            byte[] result = encoder.encode(message);
+            assertNotNull(result);
+            assertEquals(message.getOpcode().getValue(), result[0]);
+        }
+    }
+}

--- a/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpProtocolExceptionTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/network/tcp/TcpProtocolExceptionTest.java
@@ -1,0 +1,118 @@
+package com.manuscripta.student.network.tcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link TcpProtocolException}.
+ */
+public class TcpProtocolExceptionTest {
+
+    @Test
+    public void constructor_withErrorTypeAndMessage_setsFieldsCorrectly() {
+        TcpProtocolException exception = new TcpProtocolException(
+                TcpProtocolException.ErrorType.EMPTY_DATA,
+                "Test message");
+
+        assertEquals(TcpProtocolException.ErrorType.EMPTY_DATA, exception.getErrorType());
+        assertEquals("Test message", exception.getMessage());
+        assertNull(exception.getInvalidOpcode());
+    }
+
+    @Test
+    public void constructor_withInvalidOpcode_setsFieldsCorrectly() {
+        TcpProtocolException exception = new TcpProtocolException((byte) 0xFF);
+
+        assertEquals(TcpProtocolException.ErrorType.UNKNOWN_OPCODE, exception.getErrorType());
+        assertNotNull(exception.getInvalidOpcode());
+        assertEquals((byte) 0xFF, exception.getInvalidOpcode().byteValue());
+        assertTrue(exception.getMessage().contains("0xFF"));
+    }
+
+    @Test
+    public void constructor_withZeroOpcode_setsFieldsCorrectly() {
+        TcpProtocolException exception = new TcpProtocolException((byte) 0x00);
+
+        assertEquals(TcpProtocolException.ErrorType.UNKNOWN_OPCODE, exception.getErrorType());
+        assertNotNull(exception.getInvalidOpcode());
+        assertEquals((byte) 0x00, exception.getInvalidOpcode().byteValue());
+    }
+
+    @Test
+    public void getErrorType_returnsCorrectType() {
+        TcpProtocolException emptyData = new TcpProtocolException(
+                TcpProtocolException.ErrorType.EMPTY_DATA, "Empty");
+        TcpProtocolException malformed = new TcpProtocolException(
+                TcpProtocolException.ErrorType.MALFORMED_DATA, "Malformed");
+        TcpProtocolException nullMsg = new TcpProtocolException(
+                TcpProtocolException.ErrorType.NULL_MESSAGE, "Null");
+        TcpProtocolException unknown = new TcpProtocolException((byte) 0x99);
+
+        assertEquals(TcpProtocolException.ErrorType.EMPTY_DATA, emptyData.getErrorType());
+        assertEquals(TcpProtocolException.ErrorType.MALFORMED_DATA, malformed.getErrorType());
+        assertEquals(TcpProtocolException.ErrorType.NULL_MESSAGE, nullMsg.getErrorType());
+        assertEquals(TcpProtocolException.ErrorType.UNKNOWN_OPCODE, unknown.getErrorType());
+    }
+
+    @Test
+    public void getInvalidOpcode_returnsNullForNonOpcodeErrors() {
+        TcpProtocolException exception = new TcpProtocolException(
+                TcpProtocolException.ErrorType.EMPTY_DATA,
+                "Empty data");
+
+        assertNull(exception.getInvalidOpcode());
+    }
+
+    @Test
+    public void getInvalidOpcode_returnsOpcodeForOpcodeErrors() {
+        TcpProtocolException exception = new TcpProtocolException((byte) 0xAB);
+
+        assertNotNull(exception.getInvalidOpcode());
+        assertEquals((byte) 0xAB, exception.getInvalidOpcode().byteValue());
+    }
+
+    @Test
+    public void toString_withOpcode_containsOpcodeHex() {
+        TcpProtocolException exception = new TcpProtocolException((byte) 0xCD);
+
+        String result = exception.toString();
+
+        assertTrue(result.contains("UNKNOWN_OPCODE"));
+        assertTrue(result.contains("0xCD"));
+    }
+
+    @Test
+    public void toString_withoutOpcode_containsErrorTypeAndMessage() {
+        TcpProtocolException exception = new TcpProtocolException(
+                TcpProtocolException.ErrorType.MALFORMED_DATA,
+                "Bad data");
+
+        String result = exception.toString();
+
+        assertTrue(result.contains("MALFORMED_DATA"));
+        assertTrue(result.contains("Bad data"));
+    }
+
+    @Test
+    public void errorType_allValuesExist() {
+        TcpProtocolException.ErrorType[] values = TcpProtocolException.ErrorType.values();
+
+        assertEquals(4, values.length);
+        assertNotNull(TcpProtocolException.ErrorType.valueOf("EMPTY_DATA"));
+        assertNotNull(TcpProtocolException.ErrorType.valueOf("UNKNOWN_OPCODE"));
+        assertNotNull(TcpProtocolException.ErrorType.valueOf("MALFORMED_DATA"));
+        assertNotNull(TcpProtocolException.ErrorType.valueOf("NULL_MESSAGE"));
+    }
+
+    @Test
+    public void exception_extendsException() {
+        TcpProtocolException exception = new TcpProtocolException(
+                TcpProtocolException.ErrorType.EMPTY_DATA, "Test");
+
+        assertTrue(exception instanceof Exception);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `TcpMessageEncoder` to serialise TCP messages to byte arrays
- Add `TcpMessageDecoder` to deserialise byte arrays to TCP messages
- Add `TcpProtocolException` for protocol error handling with error types (EMPTY_DATA, UNKNOWN_OPCODE, MALFORMED_DATA, NULL_MESSAGE)
- Comprehensive unit tests including round-trip tests for all message types

## Changes
- `TcpMessageEncoder.java` - Encodes messages using protocol format `[1 byte: opcode][N bytes: operand]`
- `TcpMessageDecoder.java` - Decodes byte arrays and instantiates appropriate message subclasses
- `TcpProtocolException.java` - Exception with error types and invalid opcode tracking
- `TcpMessageEncoderTest.java` - 16 tests covering all message types and edge cases
- `TcpMessageDecoderTest.java` - 18 tests including error handling scenarios
- `TcpEncoderDecoderRoundTripTest.java` - 14 round-trip tests verifying data preservation
- `TcpProtocolExceptionTest.java` - Exception class tests

## Test plan
- [x] All unit tests pass (48 TCP-related tests)
- [x] Round-trip encoding/decoding preserves data for all message types
- [x] Unknown opcodes handled gracefully with TcpProtocolException
- [x] Checkstyle passes
- [x] Javadoc for all public methods

Closes #92