### PR TITLE
docs: Define session state transitions and clarify terminology

### DIFF
--- a/docs/API Contract.md
+++ b/docs/API Contract.md
@@ -98,7 +98,7 @@ Bytes 7-8:   0x18 0x17                    (5912 little-endian)
 
 ### 2.1. Lesson Materials (Server -> Client)
 
-**DELETED** - These endpoints have been removed due to security concerns (unauthorized access to all materials). Use the alternative API: `GET /session/{deviceId}` as specified in `API Contract.md` §2.5 for session-specific material distribution.
+**DELETED** - These endpoints have been removed due to security concerns (unauthorized access to all materials). Use the alternative API: `GET /distribution/{deviceId}` as specified in `API Contract.md` §2.5 for device-specific material distribution.
 
 ### 2.1.3. Attachments (Server -> Client)
 Downloads specific attachment files referenced within material content.
@@ -180,14 +180,16 @@ Submits multiple responses at once (e.g., when reconnecting after offline mode).
     ```
 -   **Response:** `201 Created`
 
-### 2.5. Session Management (Server -> Client via TCP trigger)
+### 2.5. Material Distribution (Server -> Client via TCP trigger)
 
-Used to distribute materials to devices during a session. See `Session Interaction.md` §3 for the full distribution process.
+Used to distribute materials to devices. See `Session Interaction.md` §3 for the full distribution process.
 
-#### Get Session Materials
-Retrieves materials and questions assigned to a specific device for the current session.
+**Note:** This endpoint returns a "distribution bundle" of materials and questions. The Android client creates a separate `SessionEntity` for each material received (see `Session Interaction.md` §5).
 
--   **Endpoint:** `GET /session/{deviceId}`
+#### Get Distribution Bundle
+Retrieves materials and questions assigned to a specific device.
+
+-   **Endpoint:** `GET /distribution/{deviceId}`
 -   **Response:** `200 OK`
     ```json
     {
@@ -199,7 +201,7 @@ Retrieves materials and questions assigned to a specific device for the current 
       ]
     }
     ```
--   **Error Response:** `404 Not Found` (if no active session for deviceId)
+-   **Error Response:** `404 Not Found` (if no materials available for deviceId)
 
 ---
 

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -100,22 +100,25 @@ If validation rules in API Contract are in contradiction to this document, this 
 (1) A `SessionEntity` object must have the following data fields to be considered valid:
 
     (a) `MaterialId` (UUID): References the material the student should work on during the lesson.
-    (b) `StartTime` (long): Start unix timestamp of the last interaction.
-    (c) `SessionStatus`(enum SessionStatus). Possible values are:
-        (i) `ACTIVE`: Session is currently active/ongoing.
-        (ii) `PAUSED`: Session has been paused.
-        (iii) `COMPLETED`: Session completed normally.
-        (iv) `CANCELLED`: Session was cancelled before completion.
-    (d) `DeviceId` (UUID): The device ID the session is related to.
+    (b) `SessionStatus`(enum SessionStatus). Possible values are:
+        (i) `RECEIVED`: Material has been received; student has not yet interacted.
+        (ii) `ACTIVE`: Session is currently active/ongoing.
+        (iii) `PAUSED`: Session has been paused.
+        (iv) `COMPLETED`: Session completed normally.
+        (v) `CANCELLED`: Session was cancelled before completion.
+    (c) `DeviceId` (UUID): The device ID the session is related to.
 
 (2) In addition to the mandatory fields in (1), a `SessionEntity` object may have the following fields:
 
-    (a) `EndTime` (long): End unix timestamp, for non-active sessions
+    (a) `StartTime` (long): Start unix timestamp, set when student first interacts with material.
+    (b) `EndTime` (long): End unix timestamp, for non-active sessions.
 
 (3) Data fields defined in this Section must also conform to all the following constraints for the object to be valid:
 
-    (a) A `SessionEntity` whose `SessionStatus` is `PAUSED`, `COMPLETED` or `CANCELLED` must have a `EndTime` field as specified in 2(a).
-    (b) A `DeviceId`, as specified in (1)(d), must correspond to a valid device.
+    (a) A `SessionEntity` whose `SessionStatus` is `RECEIVED` must not have `StartTime` or `EndTime`.
+    (b) A `SessionEntity` whose `SessionStatus` is `ACTIVE` must have `StartTime` but must not have `EndTime`.
+    (c) A `SessionEntity` whose `SessionStatus` is `PAUSED`, `COMPLETED` or `CANCELLED` must have both `StartTime` and `EndTime`.
+    (d) A `DeviceId`, as specified in (1)(c), must correspond to a valid device.
 
 ### Section 2E - Data Validation Rules for `DeviceStatusEntity`
 


### PR DESCRIPTION
- Add RECEIVED state to SessionStatus enum for material receipt
- Define 5-state lifecycle: RECEIVED → ACTIVE → PAUSED/COMPLETED/CANCELLED
- Clarify session = device + material association (not a bundle)
- Rename /session/{deviceId} endpoint to /distribution/{deviceId}
- Update StartTime to be optional (null for RECEIVED state)
- PAUSED now covers breaks and switching between materials

Closes ambiguity around "session" terminology across docs.