### PR TITLE
[Android] chore: reduce code coverage threshold to 95%

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -64,7 +64,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run Tests, Report, and Verify
-        # This single command runs unit tests, builds the report, and fails if < 100%
+        # This single command runs unit tests, builds the report, and fails if < 95%
         run: ./gradlew jacocoTestReport jacocoTestCoverageVerification
 
       - name: Upload Test Results (JUnit)
@@ -87,6 +87,6 @@ jobs:
         with:
           paths: android/app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 1.0
-          min-coverage-changed-files: 1.0
+          min-coverage-overall: 0.95
+          min-coverage-changed-files: 0.95
           title: Code Coverage Report

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -212,7 +212,7 @@ tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
     violationRules {
         rule {
             limit {
-                minimum = "1.0".toBigDecimal() // 100% coverage
+                minimum = "0.95".toBigDecimal() // 95% coverage
             }
         }
     }


### PR DESCRIPTION
This pull request changes test coverage threshold to 95%. Strictly enforcing 100% made sense earlier in development, but as we're working with much more complex components within the codebase 100% coverage is not always plausible. 

I have also noticed that it encourages coding agents to create brittle tests that don't actually check for expected behaviour, but just test the written implementation. Reducing the coverage check to 95% encourages the agent to have broad coverage without forcing it write useless tests. 