### PR TITLE
[Android] refactor: remove `HAND_RAISED` state from `DeviceStatus`

### DIFF
--- a/android/app/src/main/java/com/manuscripta/student/data/model/DeviceStatus.java
+++ b/android/app/src/main/java/com/manuscripta/student/data/model/DeviceStatus.java
@@ -10,11 +10,6 @@ public enum DeviceStatus {
     ON_TASK,
 
     /**
-     * Student has requested help.
-     */
-    HAND_RAISED,
-
-    /**
      * Device is disconnected or offline.
      */
     DISCONNECTED,

--- a/android/app/src/test/java/com/manuscripta/student/data/local/DeviceStatusDaoTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/data/local/DeviceStatusDaoTest.java
@@ -64,12 +64,12 @@ public class DeviceStatusDaoTest {
         DeviceStatusEntity entity1 = new DeviceStatusEntity("dev-1", DeviceStatus.ON_TASK, 100, "mat-1", "view-1", System.currentTimeMillis());
         dao.insert(entity1);
 
-        DeviceStatusEntity entity2 = new DeviceStatusEntity("dev-1", DeviceStatus.HAND_RAISED, 90, "mat-2", "view-2", System.currentTimeMillis());
+        DeviceStatusEntity entity2 = new DeviceStatusEntity("dev-1", DeviceStatus.IDLE, 90, "mat-2", "view-2", System.currentTimeMillis());
         dao.insert(entity2);
 
         DeviceStatusEntity retrieved = dao.getById("dev-1");
         assertNotNull(retrieved);
-        assertEquals(DeviceStatus.HAND_RAISED, retrieved.getStatus());
+        assertEquals(DeviceStatus.IDLE, retrieved.getStatus());
         assertEquals(90, retrieved.getBatteryLevel());
         assertEquals("mat-2", retrieved.getCurrentMaterialId());
         assertEquals("view-2", retrieved.getStudentView());

--- a/android/app/src/test/java/com/manuscripta/student/domain/mapper/DeviceStatusMapperTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/domain/mapper/DeviceStatusMapperTest.java
@@ -45,7 +45,7 @@ public class DeviceStatusMapperTest {
         // Given
         DeviceStatus domain = new DeviceStatus(
                 "device-id-789",
-                com.manuscripta.student.data.model.DeviceStatus.HAND_RAISED,
+                com.manuscripta.student.data.model.DeviceStatus.IDLE,
                 50,
                 "material-id-012",
                 "AnotherView",
@@ -145,11 +145,6 @@ public class DeviceStatusMapperTest {
         DeviceStatus onTaskDomain = DeviceStatusMapper.toDomain(onTaskEntity);
         assertEquals(com.manuscripta.student.data.model.DeviceStatus.ON_TASK, onTaskDomain.getStatus());
 
-        // Test HAND_RAISED
-        DeviceStatusEntity handRaisedEntity = new DeviceStatusEntity("id2", com.manuscripta.student.data.model.DeviceStatus.HAND_RAISED,
-                50, null, null, 2000L);
-        DeviceStatus handRaisedDomain = DeviceStatusMapper.toDomain(handRaisedEntity);
-        assertEquals(com.manuscripta.student.data.model.DeviceStatus.HAND_RAISED, handRaisedDomain.getStatus());
 
         // Test DISCONNECTED
         DeviceStatusEntity disconnectedEntity = new DeviceStatusEntity("id3", com.manuscripta.student.data.model.DeviceStatus.DISCONNECTED,

--- a/android/app/src/test/java/com/manuscripta/student/domain/model/DeviceStatusModelTest.java
+++ b/android/app/src/test/java/com/manuscripta/student/domain/model/DeviceStatusModelTest.java
@@ -42,7 +42,7 @@ public class DeviceStatusModelTest {
     public void testCreateFactoryMethod() {
         DeviceStatus newModel = DeviceStatus.create(
                 "new-device",
-                com.manuscripta.student.data.model.DeviceStatus.HAND_RAISED,
+                com.manuscripta.student.data.model.DeviceStatus.IDLE,
                 100,
                 null,
                 null
@@ -50,7 +50,7 @@ public class DeviceStatusModelTest {
 
         assertNotNull(newModel);
         assertEquals("new-device", newModel.getDeviceId());
-        assertEquals(com.manuscripta.student.data.model.DeviceStatus.HAND_RAISED, newModel.getStatus());
+        assertEquals(com.manuscripta.student.data.model.DeviceStatus.IDLE, newModel.getStatus());
         assertEquals(100, newModel.getBatteryLevel());
         assertNull(newModel.getCurrentMaterialId());
         assertNull(newModel.getStudentView());


### PR DESCRIPTION
- Remove `HAND_RAISED` enum constant from `DeviceStatus` model
- Update `DeviceStatusDaoTest`, `DeviceStatusModelTest`, and `DeviceStatusMapperTest` to use `IDLE` or other existing states instead of `HAND_RAISED`
- Remove specific test case for `HAND_RAISED` mapping in `DeviceStatusMapperTest`

Closes #129 