### PR TITLE
Added fields ReadingAge and AgeGroup to MaterialEntity in validation rules

### DIFF
--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -42,6 +42,14 @@ If validation rules in API Contract are in contradiction to this document, this 
     (b) `Title` (String). Maximum Length = 500 Characters.
     (c) `Content` (String).
     (d) `Timestamp` (Long). The unix timestamp of the previous modification.
+    (e) `ReadingAge` (int).
+    (f) `AgeGroup` (enum AgeGroupOption). Possible options are listed below.
+        (i) `FOUR_TO_SIX`: The material is targeted to users aged between 4 and 6.
+        (ii) `SEVEN_TO_NINE`: The material is targeted to users aged between 7 and 9.
+        (iii) `TEN_TO_THIRTEEN`: The material is targeted to users aged between 10 and 13.
+        (iv) `FOURTEEN_OR_ABOVE`: The material is targeted to users aged 14 or above.
+
+
 
 (2) In addition to the mandatory fields in (1), a `MaterialEntity` object may have the following fields:
 


### PR DESCRIPTION
As stated in title.

Questions to consider:
- The possible values of AgeGroup are defined here as an enum, in accordance to the existing prototype. Do we want this to be an integer instead, for the sake of flexibility?
- Do we want to rename AgeGroup to ActualAge, or something similar for consistency and to avoid confusion with ReadingAge?