### PR TITLE
Added fields ReadingAge and AgeGroup to MaterialEntity

### DIFF
--- a/windows/ManuscriptaTeacherApp/docs/specifications/MaterialHierarchySpec.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/MaterialHierarchySpec.md
@@ -56,5 +56,9 @@ This document defines the hierarchical system for grouping and organising Materi
 (1) A material is represented by a `MaterialEntity` class. In addition to those specified by Section 2A of `Validation Rules.md`, this class must also contain the following fields.
 
     (a) `LessonId` (UUID): References the lesson to which this material belongs.
-    (b) `ReadingAge` (int).
-    (c) `ActualAge` (int).
+    
+
+(2) In addition to the mandatory fields in (1), a `MaterialEntity` object may have the following fields:
+
+    (a) `ReadingAge` (int).
+    (b) `ActualAge` (int).


### PR DESCRIPTION
As stated in title. Also includes some minor corrections with grammar and typos.

Questions to consider:

- The possible values of AgeGroup are defined here as an enum, in accordance to the existing prototype. Do we want this to be an integer instead, for the sake of flexibility?
- Do we want to rename AgeGroup to ActualAge, or something similar for consistency and to avoid confusion with ReadingAge?