### PR TITLE
Updated docs with FeedbackEntity and corresponding networking specs

### DIFF
--- a/docs/API Contract.md
+++ b/docs/API Contract.md
@@ -195,7 +195,25 @@ Retrieves materials and questions assigned to a specific device.
     ```
 -   **Error Response:** `404 Not Found` (if no materials available for deviceId)
 
----
+
+### 2.6. Returning Feedback (Server -> Client via TCP trigger)
+
+Retrieves feedback for a specific response previously submitted specific device.
+
+-   **Endpoint:** `GET /distribution/{deviceId}`
+-   **Response:** `200 OK`
+    ```json
+    {
+      "materials": [
+        // Array of MaterialEntity objects as defined in Validation Rules.md §2A
+      ],
+      "questions": [
+        // Array of QuestionEntity objects as defined in Validation Rules.md §2B
+      ]
+    }
+    ```
+-   **Error Response:** `404 Not Found` (if no materials available for deviceId)
+
 
 ## 3. Binary Protocol (TCP & UDP)
 
@@ -238,6 +256,7 @@ See §1.1 for detailed format.
 | `0x04` | UNPAIR | None | Unpairs the device |
 | `0x05` | DISTRIBUTE_MATERIAL | None | Instructs device to fetch materials for a session |
 | `0x06` | HAND_ACK | Device ID (UTF-8 string) | Acknowledges receipt of HAND_RAISED message |
+| `0x07` | RETURN_FEEDBACK | None | Instructs device to retrieve feedback for a response |
 
 ### 3.5. TCP Pairing Messages
 
@@ -273,6 +292,7 @@ Byte 0: 0x21 (PAIRING_ACK opcode)
 | `0x10` | STATUS_UPDATE | JSON payload | Reports device status to teacher |
 | `0x11` | HAND_RAISED | Device ID (UTF-8 string) | Student requests help |
 | `0x12` | DISTRIBUTE_ACK | Device ID (UTF-8 string) | Acknowledges successful receipt of materials via HTTP `GET /distribution/{deviceId}` |
+| `0x13` | FEEDBACK_ACK | Device ID (UTF-8 string) | Acknowledges successful receipt of feedback via HTTP `GET /feedback/{deviceId}` |
 
 **Example: Status Update Message**
 ```
@@ -309,6 +329,7 @@ This section documents explicit and implicit acknowledgement mechanisms for TCP 
 | `PAIRING_REQUEST (0x20)` | `PAIRING_ACK (0x21)` | Client → Server, Server → Client |
 | `HAND_RAISED (0x11)` | `HAND_ACK (0x06)` | Client → Server, Server → Client |
 | `DISTRIBUTE_MATERIAL (0x05)` | `DISTRIBUTE_ACK (0x12)` | Server → Client, Client → Server |
+| `RETURN_FEEDBACK (0x06)` | `FEEDBACK_ACK (0x13)` | Server → Client, Client → Server |
 
 #### Implicit ACKs
 

--- a/docs/Session Interaction.md
+++ b/docs/Session Interaction.md
@@ -89,3 +89,13 @@ Per `Validation Rules.md` §2D(3)(a), any transition to `PAUSED`, `COMPLETED`, o
 (7) **Automatic Cancellation**
 
 A session shall be automatically transitioned to `CANCELLED` if the device is deemed unpaired as defined in Section 2(4) of this document.
+
+
+
+## Section 6: Returning Feedback
+
+(1) The Windows client returns feedback by sending a TCP `RETURN_FEEDBACK` message (opcode `0x06`), as specified in `API Contract.md` §3.4, to the Android device which are the intended recipient.
+
+(2) The Android client must, on receipt of the message specified in (1), call `GET /feedback/{deviceId}` as specified in `API Contract.md` §2.6, to retrieve all feedback available thereto.
+
+(3) For each feedback received from the endpoint in (2), the Android client creates a separate `FeedbackEntity`.

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -89,7 +89,7 @@ If validation rules in API Contract are in contradiction to this document, this 
 
 (3) Data fields defined in this Section must also conform to all the following constraints for the object to be valid:
 
-    (a) The `QuestionId` specified in 1(a) must associate with a `QuestionMaterial` (Q).
+    (a) The `QuestionId` specified in 1(a) must associate with a `QuestionEntity` (Q).
     (b) If Q's `QuestionType` is `MULTIPLE_CHOICE`, the `Answer`, specified in 2(a), must be a valid index in Q's `Options`.
     (c) If Q's `QuestionType` is `TRUE_FALSE`, the `Answer`, specified in 2(a), must be a valid boolean value.
     (d) If Q's `QuestionType` is `WRITTEN_ANSWER`, the `Answer` should be a valid String.
@@ -140,6 +140,26 @@ If validation rules in API Contract are in contradiction to this document, this 
     (a) The `DeviceId` specified in (1)(a) must reference a valid Device, which is deemed paired as defined in Pairing Process Specification.
     (b) The `BatteryLevel` specified in (1)(c) must be between 0 and 100.
     (c) The `CurrentMaterialId` specified in (1)(d) must reference a valid material.
+
+
+### Section 2F - Data Validation Rules for `FeedbackEntity`
+
+(1) A `FeedbackEntity` object must have the following data fields to be considered valid:
+
+    (a) `ResponseId` (UUID). The response targeted by this feedback.
+
+
+(2) In addition to the mandatory fields in (1), a `ResponseEntity` object may have the following fields:
+
+    (a) `Text` (String): Textual feedback.
+
+    (b) `Marks` (int): Number of marks awarded to the response.
+
+
+(3) Data fields defined in this Section must also conform to all the following constraints for the object to be valid:
+
+    (a) The `ResponseId` specified in 1(a) must associate with a `ResponseEntity` (R).
+
 
 ### Section 3 - ID Generation Policy
 


### PR DESCRIPTION
This PR adds specifications for `FeedbackEntity`, which represents a piece of feedback for a response previously submitted by a student.

## Questions to consider prior to merging this PR

1. As the specifications for `ResponseEntity` currently stand, they include the following optional Boolean field `IsCorrect`, stating that "the android device may assist in validating simple questions (such as Multiple Choice, True/False or simple blank filling)". However, the scope of "simple questions" have yet to be finalised. When should feedback be given through `FeedbackEntity`, and when should it be determined by the Android device itself?
2. Are all questions (and hence responses) subject to textual feedback? What about numerical marking? If so, a `maxMarks` attribute will likely have to be added to `QuestionEntity` objects.

TLDR: When and how should feedback (be it numerical or textual) be given?

