### PR TITLE
Added one-response-per-question-per-tablet restriction

### DIFF
--- a/docs/Session Interaction.md
+++ b/docs/Session Interaction.md
@@ -45,6 +45,9 @@ As specified in `API Contract.md` §2.5.
 
 (2) The Android client may evaluate the correctness of the response if it is straightforward to do so (such as for multiple choice, true / false or simple blank filling questions), and place the result of evaluation in the `IsCorrect` field. 
 
+(3) Each Android client must not, at any point, submit two responses related to the same question.
+
+
 ## Section 5: Lifetime of a Session
 
 (1) **Session States**

--- a/docs/Validation Rules.md
+++ b/docs/Validation Rules.md
@@ -94,6 +94,8 @@ If validation rules in API Contract are in contradiction to this document, this 
     (c) If Q's `QuestionType` is `TRUE_FALSE`, the `Answer`, specified in 2(a), must be a valid boolean value.
     (d) If Q's `QuestionType` is `WRITTEN_ANSWER`, the `Answer` should be a valid String.
     (e) A `DeviceId`, as specified in (1)(d), must correspond to a valid device.
+    (f) There must not already exist a previously created `ResponseEntity` object with an identical `QuestionId` and `DeviceId` combination.
+
 
 ### Section 2D - Data Validation Rules for `SessionEntity`
 


### PR DESCRIPTION
This PR introduces to the documentation an additional restriction on submitting responses:

> Each Android tablet must submit at most one response to each question.

If a newly created `ResponseEntity` shares the same `QuestionId` and `DeviceId` with an existing one, the new entity is considered invalid.