### PR TITLE
[Windows] Implement Unpair Functionalities and Timeout Detection

### DIFF
--- a/windows/ManuscriptaTeacherApp/Main/Controllers/ConfigController.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Controllers/ConfigController.cs
@@ -1,32 +1,42 @@
 using Microsoft.AspNetCore.Mvc;
+using Main.Services.Network;
 
 namespace Main.Controllers;
 
 /// <summary>
 /// Controller for device configuration.
-/// Implements dummy endpoint for /config.
+/// Implements GET /config/{deviceId} per API Contract.md §2.2.
 /// </summary>
 [ApiController]
 [Route("api/v1")]
 public class ConfigController : ControllerBase
 {
     private readonly ILogger<ConfigController> _logger;
+    private readonly IRefreshConfigTracker _refreshTracker;
 
-    public ConfigController(ILogger<ConfigController> logger)
+    public ConfigController(
+        ILogger<ConfigController> logger,
+        IRefreshConfigTracker refreshTracker)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _refreshTracker = refreshTracker ?? throw new ArgumentNullException(nameof(refreshTracker));
     }
 
     /// <summary>
     /// Gets the configuration for the device.
-    /// Per API Contract.md §2.2: GET /config
+    /// Per API Contract.md §2.2: GET /config/{deviceId}
+    /// Also serves as implicit ACK for REFRESH_CONFIG per Session Interaction.md §6(3).
     /// </summary>
+    /// <param name="deviceId">The device requesting configuration.</param>
     /// <returns>200 OK with configuration.</returns>
-    [HttpGet("config")]
+    [HttpGet("config/{deviceId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
-    public IActionResult GetConfig()
+    public IActionResult GetConfig(string deviceId)
     {
-        _logger.LogInformation("Configuration requested");
+        _logger.LogInformation("Configuration requested by {DeviceId}", deviceId);
+
+        // Signal that this device has fetched config (ACK for REFRESH_CONFIG)
+        _refreshTracker.MarkConfigReceived(deviceId);
 
         // Dummy configuration as stated in the provisional API contract
         return Ok(new
@@ -36,3 +46,4 @@ public class ConfigController : ControllerBase
         });
     }
 }
+

--- a/windows/ManuscriptaTeacherApp/Main/Models/Events/ControlTimeoutEventArgs.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Models/Events/ControlTimeoutEventArgs.cs
@@ -1,0 +1,26 @@
+namespace Main.Models.Events;
+
+/// <summary>
+/// Event arguments for control command timeout notifications.
+/// Raised when a control signal expecting implicit acknowledgement times out.
+/// Per Session Interaction.md §6(2) and §6(3).
+/// </summary>
+public class ControlTimeoutEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the device ID that the command was sent to.
+    /// </summary>
+    public string DeviceId { get; }
+
+    /// <summary>
+    /// Gets the name of the command that timed out.
+    /// E.g., "LOCK_SCREEN", "UNLOCK_SCREEN", "REFRESH_CONFIG".
+    /// </summary>
+    public string CommandName { get; }
+
+    public ControlTimeoutEventArgs(string deviceId, string commandName)
+    {
+        DeviceId = deviceId;
+        CommandName = commandName;
+    }
+}

--- a/windows/ManuscriptaTeacherApp/Main/Models/Events/DeviceStatusEventArgs.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Models/Events/DeviceStatusEventArgs.cs
@@ -1,0 +1,54 @@
+namespace Main.Models.Events;
+
+/// <summary>
+/// Event arguments for device status update notifications.
+/// Raised when a STATUS_UPDATE (0x10) message is received per Session Interaction.md §2.
+/// </summary>
+public class DeviceStatusEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the device ID that sent the status update.
+    /// </summary>
+    public string DeviceId { get; }
+
+    /// <summary>
+    /// Gets the status string reported by the device.
+    /// </summary>
+    public string Status { get; }
+
+    /// <summary>
+    /// Gets the battery level (0-100).
+    /// </summary>
+    public int BatteryLevel { get; }
+
+    /// <summary>
+    /// Gets the current material ID the device is viewing.
+    /// </summary>
+    public string? CurrentMaterialId { get; }
+
+    /// <summary>
+    /// Gets the student's current view position.
+    /// </summary>
+    public string? StudentView { get; }
+
+    /// <summary>
+    /// Gets the timestamp of the status update.
+    /// </summary>
+    public long Timestamp { get; }
+
+    public DeviceStatusEventArgs(
+        string deviceId,
+        string status,
+        int batteryLevel,
+        string? currentMaterialId,
+        string? studentView,
+        long timestamp)
+    {
+        DeviceId = deviceId;
+        Status = status;
+        BatteryLevel = batteryLevel;
+        CurrentMaterialId = currentMaterialId;
+        StudentView = studentView;
+        Timestamp = timestamp;
+    }
+}

--- a/windows/ManuscriptaTeacherApp/Main/Program.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Program.cs
@@ -20,6 +20,7 @@ builder.Services.AddScoped<IDeviceRegistryService, DeviceRegistryService>();
 builder.Services.AddScoped<DeviceIdValidator>();
 
 // Register network services (singletons for background services)
+builder.Services.AddSingleton<IRefreshConfigTracker, RefreshConfigTracker>();
 builder.Services.AddSingleton<IUdpBroadcastService, UdpBroadcastService>();
 builder.Services.AddSingleton<ITcpPairingService, TcpPairingService>();
 

--- a/windows/ManuscriptaTeacherApp/Main/Services/DeviceRegistryService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/DeviceRegistryService.cs
@@ -59,4 +59,23 @@ public class DeviceRegistryService : IDeviceRegistryService
         return await _context.PairedDevices
             .AnyAsync(d => d.DeviceId == deviceId);
     }
+
+    /// <inheritdoc />
+    public async Task<bool> UnregisterDeviceAsync(Guid deviceId)
+    {
+        var device = await _context.PairedDevices
+            .FirstOrDefaultAsync(d => d.DeviceId == deviceId);
+
+        if (device == null)
+        {
+            _logger.LogInformation("Device {DeviceId} not found in registry, nothing to remove", deviceId);
+            return false;
+        }
+
+        _context.PairedDevices.Remove(device);
+        await _context.SaveChangesAsync();
+
+        _logger.LogInformation("Device {DeviceId} unpaired and removed from registry", deviceId);
+        return true;
+    }
 }

--- a/windows/ManuscriptaTeacherApp/Main/Services/IDeviceRegistryService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/IDeviceRegistryService.cs
@@ -24,4 +24,12 @@ public interface IDeviceRegistryService
     /// <param name="deviceId">The device ID to check.</param>
     /// <returns>True if the device is paired; otherwise, false.</returns>
     Task<bool> IsDevicePairedAsync(Guid deviceId);
+
+    /// <summary>
+    /// Removes a device from the registry (unpairing).
+    /// Per Pairing Process.md §3(2): "It should also remove the Android client from its registry."
+    /// </summary>
+    /// <param name="deviceId">The device ID to remove.</param>
+    /// <returns>True if the device was removed; false if it wasn't registered.</returns>
+    Task<bool> UnregisterDeviceAsync(Guid deviceId);
 }

--- a/windows/ManuscriptaTeacherApp/Main/Services/Network/IRefreshConfigTracker.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/Network/IRefreshConfigTracker.cs
@@ -1,0 +1,22 @@
+namespace Main.Services.Network;
+
+/// <summary>
+/// Interface for tracking REFRESH_CONFIG acknowledgements.
+/// Per Session Interaction.md §6(3): tracks GET /config requests as implicit ACKs.
+/// </summary>
+public interface IRefreshConfigTracker
+{
+    /// <summary>
+    /// Registers that a REFRESH_CONFIG was sent and we expect a GET /config.
+    /// </summary>
+    /// <param name="deviceId">The device ID that should call GET /config.</param>
+    /// <param name="tcs">TaskCompletionSource to signal when config is received.</param>
+    void ExpectConfigRequest(string deviceId, TaskCompletionSource<bool> tcs);
+
+    /// <summary>
+    /// Called when a GET /config/{deviceId} request is received.
+    /// Completes the pending TaskCompletionSource if one exists.
+    /// </summary>
+    /// <param name="deviceId">The device ID that made the request.</param>
+    void MarkConfigReceived(string deviceId);
+}

--- a/windows/ManuscriptaTeacherApp/Main/Services/Network/ITcpPairingService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/Network/ITcpPairingService.cs
@@ -36,4 +36,35 @@ public interface ITcpPairingService
     /// Sends a DISTRIBUTE_MATERIAL (0x05) command to the specified device and waits for DISTRIBUTE_ACK.
     /// </summary>
     Task SendDistributeMaterialAsync(string deviceId);
+
+    /// <summary>
+    /// Sends an UNPAIR (0x04) command to the specified device and removes it from registry.
+    /// Per Pairing Process.md §3(2).
+    /// </summary>
+    Task SendUnpairAsync(string deviceId);
+
+    /// <summary>
+    /// Sends a REFRESH_CONFIG (0x03) command to the specified device.
+    /// Per Session Interaction.md §6(3).
+    /// </summary>
+    Task SendRefreshConfigAsync(string deviceId);
+
+    /// <summary>
+    /// Event raised when a device status update (STATUS_UPDATE 0x10) is received.
+    /// Per Session Interaction.md §2.
+    /// </summary>
+    event EventHandler<Models.Events.DeviceStatusEventArgs>? StatusUpdateReceived;
+
+    /// <summary>
+    /// Event raised when a device is deemed disconnected due to heartbeat silence.
+    /// Per Session Interaction.md §2(3): after 10 seconds of no heartbeat.
+    /// </summary>
+    event EventHandler<Models.Events.DeviceStatusEventArgs>? DeviceDisconnected;
+
+    /// <summary>
+    /// Event raised when a control command times out waiting for implicit acknowledgement.
+    /// Per Session Interaction.md §6(2) and §6(3).
+    /// </summary>
+    event EventHandler<Models.Events.ControlTimeoutEventArgs>? ControlCommandTimedOut;
 }
+

--- a/windows/ManuscriptaTeacherApp/Main/Services/Network/RefreshConfigTracker.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/Network/RefreshConfigTracker.cs
@@ -1,0 +1,27 @@
+using System.Collections.Concurrent;
+
+namespace Main.Services.Network;
+
+/// <summary>
+/// Implementation of REFRESH_CONFIG acknowledgement tracking.
+/// Per Session Interaction.md §6(3): tracks GET /config requests as implicit ACKs.
+/// </summary>
+public class RefreshConfigTracker : IRefreshConfigTracker
+{
+    private readonly ConcurrentDictionary<string, TaskCompletionSource<bool>> _pendingRequests = new();
+
+    /// <inheritdoc />
+    public void ExpectConfigRequest(string deviceId, TaskCompletionSource<bool> tcs)
+    {
+        _pendingRequests[deviceId] = tcs;
+    }
+
+    /// <inheritdoc />
+    public void MarkConfigReceived(string deviceId)
+    {
+        if (_pendingRequests.TryRemove(deviceId, out var tcs))
+        {
+            tcs.TrySetResult(true);
+        }
+    }
+}

--- a/windows/ManuscriptaTeacherApp/MainTests/ControllersTests/ConfigControllerTests.cs
+++ b/windows/ManuscriptaTeacherApp/MainTests/ControllersTests/ConfigControllerTests.cs
@@ -2,23 +2,26 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Main.Controllers;
+using Main.Services.Network;
 using Xunit;
 
 namespace MainTests.ControllersTests;
 
 /// <summary>
 /// Unit tests for ConfigController.
-/// Verifies GET /config endpoint per API Contract.md §2.2.
+/// Verifies GET /config/{deviceId} endpoint per API Contract.md §2.2.
 /// </summary>
 public class ConfigControllerTests
 {
     private readonly ConfigController _controller;
     private readonly Mock<ILogger<ConfigController>> _mockLogger;
+    private readonly Mock<IRefreshConfigTracker> _mockRefreshTracker;
 
     public ConfigControllerTests()
     {
         _mockLogger = new Mock<ILogger<ConfigController>>();
-        _controller = new ConfigController(_mockLogger.Object);
+        _mockRefreshTracker = new Mock<IRefreshConfigTracker>();
+        _controller = new ConfigController(_mockLogger.Object, _mockRefreshTracker.Object);
     }
 
     #region Constructor Tests
@@ -27,18 +30,28 @@ public class ConfigControllerTests
     public void Constructor_NullLogger_ThrowsArgumentNullException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new ConfigController(null!));
+        Assert.Throws<ArgumentNullException>(() => new ConfigController(null!, _mockRefreshTracker.Object));
+    }
+
+    [Fact]
+    public void Constructor_NullRefreshTracker_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new ConfigController(_mockLogger.Object, null!));
     }
 
     #endregion
 
-    #region GET /api/v1/config Tests
+    #region GET /api/v1/config/{deviceId} Tests
 
     [Fact]
     public void GetConfig_Returns200Ok()
     {
+        // Arrange
+        var deviceId = Guid.NewGuid().ToString();
+
         // Act
-        var result = _controller.GetConfig();
+        var result = _controller.GetConfig(deviceId);
 
         // Assert
         Assert.IsType<OkObjectResult>(result);
@@ -47,8 +60,11 @@ public class ConfigControllerTests
     [Fact]
     public void GetConfig_LogsInformation()
     {
+        // Arrange
+        var deviceId = Guid.NewGuid().ToString();
+
         // Act
-        _controller.GetConfig();
+        _controller.GetConfig(deviceId);
 
         // Assert
         _mockLogger.Verify(
@@ -61,5 +77,21 @@ public class ConfigControllerTests
             Times.Once);
     }
 
+    [Fact]
+    public void GetConfig_CallsRefreshTrackerMarkConfigReceived()
+    {
+        // Arrange
+        var deviceId = Guid.NewGuid().ToString();
+
+        // Act
+        _controller.GetConfig(deviceId);
+
+        // Assert - Verify that MarkConfigReceived was called with the device ID
+        _mockRefreshTracker.Verify(
+            t => t.MarkConfigReceived(deviceId),
+            Times.Once);
+    }
+
     #endregion
 }
+


### PR DESCRIPTION
Summary of changes:

- In `DeviceRegistryService.cs`, add the ability to unregister a device from the registry.
- In `TcpPairingService.cs`:
    - Add inference for "DISCONNECTED" states, per s2(3) of the Session Interaction Specification
    - Add unpairing capabilities, per s3(2) of the Pairing Process Specification
    - Add implicit timeout mechanisms for lock/unlock message, per s6(2) of the Session Interaction Specification
- In `ConfigController.cs`, add provisional refresh-config tracking using `RefreshConfigTracker.cs`, per s6(3) of the Session Interaction Specification. (The addition of `deviceId` as a path variable is to be confirmed later with the android team)
