### PR TITLE
[Windows] Remove explicit delete cascading from services

### DIFF
--- a/windows/ManuscriptaTeacherApp/Main/Services/LessonService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/LessonService.cs
@@ -1,30 +1,26 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Main.Models.Entities;
-using Main.Models.Entities.Materials;
 using Main.Services.Repositories;
 
 namespace Main.Services;
 
 /// <summary>
 /// Service for managing lessons.
-/// Enforces business rules and handles cascade deletion per PersistenceAndCascadingRules.md §2(5).
+/// Enforces business rules per AdditionalValidationRules.md §2C.
+/// Cascade deletion of materials is handled by database FK constraints per PersistenceAndCascadingRules.md §2(5).
 /// </summary>
 public class LessonService : ILessonService
 {
     private readonly ILessonRepository _repository;
     private readonly IUnitRepository _unitRepository;
-    private readonly IMaterialRepository _materialRepository;
 
     public LessonService(
         ILessonRepository repository,
-        IUnitRepository unitRepository,
-        IMaterialRepository materialRepository)
+        IUnitRepository unitRepository)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitRepository = unitRepository ?? throw new ArgumentNullException(nameof(unitRepository));
-        _materialRepository = materialRepository ?? throw new ArgumentNullException(nameof(materialRepository));
     }
 
     public async Task<LessonEntity> CreateAsync(LessonEntity entity)
@@ -54,15 +50,8 @@ public class LessonService : ILessonService
 
     public async Task DeleteAsync(Guid id)
     {
-        // Per PersistenceAndCascadingRules.md §2(5): Delete associated materials first
-        // Get all materials and delete those associated with this lesson
-        var allMaterials = await _materialRepository.GetAllAsync();
-        foreach (var material in allMaterials)
-        {
-            // MaterialEntity doesn't have LessonId (it's in MaterialDataEntity)
-            // The cascade delete in the database handles this automatically
-        }
-
+        // Cascade deletion of materials is handled by database FK constraints
+        // per PersistenceAndCascadingRules.md §2(5)
         await _repository.DeleteAsync(id);
     }
 

--- a/windows/ManuscriptaTeacherApp/Main/Services/MaterialService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/MaterialService.cs
@@ -1,32 +1,26 @@
 using System;
-
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Main.Models.Entities;
 using Main.Models.Entities.Materials;
-using Main.Models.Entities.Questions;
-using Main.Models.Enums;
 using Main.Services.Repositories;
 
 namespace Main.Services;
 
 /// <summary>
-/// Service for managing materials and their associated questions.
-/// Enforces business rules and data validation.
+/// Service for managing materials.
+/// Enforces business rules and data validation per AdditionalValidationRules.md §2D.
+/// Cascade deletion of questions is handled by database FK constraints per PersistenceAndCascadingRules.md §2(1).
 /// </summary>
 public class MaterialService : IMaterialService
 {
     private readonly IMaterialRepository _materialRepository;
-    private readonly IQuestionRepository _questionRepository;
     private readonly ILessonRepository _lessonRepository;
 
     public MaterialService(
         IMaterialRepository materialRepository, 
-        IQuestionRepository questionRepository,
         ILessonRepository lessonRepository)
     {
         _materialRepository = materialRepository ?? throw new ArgumentNullException(nameof(materialRepository));
-        _questionRepository = questionRepository ?? throw new ArgumentNullException(nameof(questionRepository));
         _lessonRepository = lessonRepository ?? throw new ArgumentNullException(nameof(lessonRepository));
     }
 
@@ -63,16 +57,8 @@ public class MaterialService : IMaterialService
 
     public async Task DeleteMaterialAsync(Guid id)
     {
-        // Get all questions associated with this material
-        var questions = await _questionRepository.GetByMaterialIdAsync(id);
-
-        // Delete all associated questions first
-        foreach (var question in questions)
-        {
-            await _questionRepository.DeleteAsync(question.Id);
-        }
-
-        // Delete the material
+        // Cascade deletion of questions is handled by database FK constraints
+        // per PersistenceAndCascadingRules.md §2(1)
         await _materialRepository.DeleteAsync(id);
     }
 

--- a/windows/ManuscriptaTeacherApp/Main/Services/UnitCollectionService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/UnitCollectionService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Main.Models.Entities;
 using Main.Services.Repositories;
@@ -8,19 +7,16 @@ namespace Main.Services;
 
 /// <summary>
 /// Service for managing unit collections.
-/// Enforces business rules and handles cascade deletion per PersistenceAndCascadingRules.md §2(3).
+/// Enforces business rules per AdditionalValidationRules.md §2A.
+/// Cascade deletion of units is handled by database FK constraints per PersistenceAndCascadingRules.md §2(3).
 /// </summary>
 public class UnitCollectionService : IUnitCollectionService
 {
     private readonly IUnitCollectionRepository _repository;
-    private readonly IUnitRepository _unitRepository;
 
-    public UnitCollectionService(
-        IUnitCollectionRepository repository,
-        IUnitRepository unitRepository)
+    public UnitCollectionService(IUnitCollectionRepository repository)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
-        _unitRepository = unitRepository ?? throw new ArgumentNullException(nameof(unitRepository));
     }
 
     public async Task<UnitCollectionEntity> CreateAsync(UnitCollectionEntity entity)
@@ -50,15 +46,8 @@ public class UnitCollectionService : IUnitCollectionService
 
     public async Task DeleteAsync(Guid id)
     {
-        // Per PersistenceAndCascadingRules.md §2(3): Delete associated units first
-        // Note: Database cascade delete will handle this automatically,
-        // but we explicitly delete here for consistency with service-layer cascade pattern
-        var units = await _unitRepository.GetByUnitCollectionIdAsync(id);
-        foreach (var unit in units)
-        {
-            await _unitRepository.DeleteAsync(unit.Id);
-        }
-
+        // Cascade deletion of units is handled by database FK constraints
+        // per PersistenceAndCascadingRules.md §2(3)
         await _repository.DeleteAsync(id);
     }
 

--- a/windows/ManuscriptaTeacherApp/Main/Services/UnitService.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Services/UnitService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using Main.Models.Entities;
 using Main.Services.Repositories;
@@ -8,22 +7,20 @@ namespace Main.Services;
 
 /// <summary>
 /// Service for managing units.
-/// Enforces business rules and handles cascade deletion per PersistenceAndCascadingRules.md §2(4).
+/// Enforces business rules per AdditionalValidationRules.md §2B.
+/// Cascade deletion of lessons is handled by database FK constraints per PersistenceAndCascadingRules.md §2(4).
 /// </summary>
 public class UnitService : IUnitService
 {
     private readonly IUnitRepository _repository;
     private readonly IUnitCollectionRepository _unitCollectionRepository;
-    private readonly ILessonRepository _lessonRepository;
 
     public UnitService(
         IUnitRepository repository,
-        IUnitCollectionRepository unitCollectionRepository,
-        ILessonRepository lessonRepository)
+        IUnitCollectionRepository unitCollectionRepository)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitCollectionRepository = unitCollectionRepository ?? throw new ArgumentNullException(nameof(unitCollectionRepository));
-        _lessonRepository = lessonRepository ?? throw new ArgumentNullException(nameof(lessonRepository));
     }
 
     public async Task<UnitEntity> CreateAsync(UnitEntity entity)
@@ -53,13 +50,8 @@ public class UnitService : IUnitService
 
     public async Task DeleteAsync(Guid id)
     {
-        // Per PersistenceAndCascadingRules.md §2(4): Delete associated lessons first
-        var lessons = await _lessonRepository.GetByUnitIdAsync(id);
-        foreach (var lesson in lessons)
-        {
-            await _lessonRepository.DeleteAsync(lesson.Id);
-        }
-
+        // Cascade deletion of lessons is handled by database FK constraints
+        // per PersistenceAndCascadingRules.md §2(4)
         await _repository.DeleteAsync(id);
     }
 

--- a/windows/ManuscriptaTeacherApp/docs/specifications/PersistenceAndCascadingRules.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/PersistenceAndCascadingRules.md
@@ -23,6 +23,8 @@ This document is effective for the Windows app only.
     (a) "Long-term persistence" means that data must be retrievable after the application restarts.
     (b) "Short-term persistence" means that unless otherwise specified, data must be retrievable during the corresponding application run, but must not be persisted beyond the application run.
 
+(4) The provisions in this document shall define required outcome behaviour. They do not mandate any particular implementation mechanism. An implementation that achieves these outcomes through any means (including but not limited to database foreign key constraints, service-layer logic, or any combination thereof) shall be considered compliant.
+
 ## Section 2 - Requirements for Orphan Removal
 
 (1) The deletion of a material M must delete any questions associated with M.


### PR DESCRIPTION
Per PR #157 decision, removed explicit cascade deletion from service layer. Database FK constraints now handle orphan removal per PersistenceAndCascadingRules.md §2.

Changes:
- UnitCollectionService: removed IUnitRepository dependency and explicit unit deletion
- UnitService: removed ILessonRepository dependency and explicit lesson deletion
- LessonService: removed IMaterialRepository dependency and vestigial loop
- MaterialService: removed IQuestionRepository dependency and explicit question deletion
- Updated corresponding service tests to remove cascade mocks/tests
- Added s1(4) to PersistenceAndCascadingRules.md clarifying that specs define required outcomes, not implementation mechanisms, in response to previous AI hallucinations

Note: QuestionService retains explicit response cascade (responses are in-memory only)