### PR TITLE
[Windows] Source documents specification

### DIFF
--- a/windows/ManuscriptaTeacherApp/docs/specifications/AdditionalValidationRules.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/AdditionalValidationRules.md
@@ -41,8 +41,6 @@ This document defines the hierarchical system for grouping and organising Materi
 
     (c) [Deleted.]
 
-    (d) `SourceDocumentTranscripts` (List<String>): A list of transcripts, each read from a source document imported for this unit.
-
 
 ### Section 2C - Lesson
 
@@ -68,3 +66,15 @@ This document defines the hierarchical system for grouping and organising Materi
     (b) `ActualAge` (int).
 
 (3) Additional fields defined in this Section do not apply to the Data Transfer Objects (DTOs) used for communication with the Android client, specified in the API Contract.
+
+
+
+## Section 3 - Entity classes Not Belonging to the Material Hierarchy
+
+## Section 3A - Source Document
+
+(1) A source document is represented by a `SourceDocumentEntity` class. This class must contain the following attributes.
+
+    (a) `UnitCollectionId` (UUID): References the unit collection to which this source document is imported.
+
+    (b) `Transcript` (string): A textual transcript of the source document contents.

--- a/windows/ManuscriptaTeacherApp/docs/specifications/NetworkingAPISpec.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/NetworkingAPISpec.md
@@ -83,6 +83,14 @@ For a description of how these server methods and client handlers are expected t
 
     (j) Methods for updating app settings. **To be confirmed.**
 
+    (k) Creation, retrieval and deletion methods for source documents.
+
+        (i) `Task CreateSourceDocument(SourceDocumentEntity newSourceDocumentEntity)`: Receives data for a new source document entity (without an assigned UUID), and creates the entity with an assigned UUID.
+
+        (ii) `Task<List<SourceDocumentEntity>> GetAllSourceDocuments()`: Retrieves all source document entities.
+
+        (iii) `Task DeleteSourceDocument(Guid id)`: Deletes a source document entity, identified by its UUID.
+
 
 
 

--- a/windows/ManuscriptaTeacherApp/docs/specifications/NetworkingInteractionSpec.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/NetworkingInteractionSpec.md
@@ -61,6 +61,8 @@ For a list of all server method and client handlers to be implemented, see `Netw
 
         (iv) `Task<List<MaterialEntity>> GetAllMaterials()`
 
+        (v) `Task<List<SourceDocumentEntity>> GetAllSourceDocuments()`
+
 
 ## Section 4 - Functionalities for the "Library" tab
 

--- a/windows/ManuscriptaTeacherApp/docs/specifications/PersistenceAndCascadingRules.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/PersistenceAndCascadingRules.md
@@ -35,6 +35,8 @@ This document is effective for the Windows app only.
 
 (3) The deletion of a unit collection C must delete any units associated with C.
 
+(3A) The deletion of a unit collection C must delete any source documents associated with C.
+
 (4) The deletion of a unit U must delete any lessons associated with U.
 
 (5) The deletion of a lesson L must delete any materials associated with L.


### PR DESCRIPTION
Specifies SourceDocumentEntity.

- A source document is a auxiliary reference file or document used to assist the LLM in generating materials.
- Source documents are stored locally on the Windows laptop.
- Source documents exist at the unit level.
- Each SourceDocumentEntity holds a UUID reference to its unit, its file path and its textual transcription.