### PR TITLE
[Windows/Docs] Specifications for AI-based Auto-marking

### DIFF
--- a/windows/ManuscriptaTeacherApp/docs/specifications/AdditionalValidationRules.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/AdditionalValidationRules.md
@@ -22,6 +22,8 @@ This document defines the hierarchical system for grouping and organising Materi
 
 (5) The applicability of this document, as well as Sections 2A to 2C (`MaterialEntity`, `QuestionEntity`, `ResponseEntity`) of `Validation Rules.md`, shall extend to the corresponding Data Entities, enforced implicitly by the polymorphic domain entity classes, and explicitly by the appropriate services.
 
+(6) For the purpose of this document, "contain" in relation to a data field means "contain a non-null value for".
+
 ## Section 2 - Entity classes for Each Hierarchical Level
 
 ### Section 2A - Unit Collection
@@ -65,8 +67,22 @@ This document defines the hierarchical system for grouping and organising Materi
     (a) `ReadingAge` (int).
     (b) `ActualAge` (int).
 
-(3) Additional fields defined in this Section do not apply to the Data Transfer Objects (DTOs) used for communication with the Android client, specified in the API Contract.
+(3) Additional fields defined in this Section shall not appear in the Data Transfer Objects (DTOs) used for communication with the Android client, specified in the API Contract.
 
+
+### Section 2E - Question
+
+(1) A question is represented by a `QuestionEntity` class. In addition to those specified by Section 2B of `Validation Rules.md`, this class may contain the following optional fields:
+
+    (a) `MarkScheme` (string). The mark scheme for the question, for the purpose of AI-marking.
+
+(2) Data fields defined in this Section must also conform to all the following constraints for the object to be valid:
+
+    (a) A `QuestionEntity` object of type `MULTIPLE_CHOICE` must not have a `MarkScheme` defined in (1)(a).
+
+    (b) A `QuestionEntity` object may not simultaneously contain `MarkScheme` and `CorrectAnswer` fields.
+
+(3) Additional fields defined in this Section shall not appear in the Data Transfer Objects (DTOs) used for communication with the Android client, specified in the API Contract.
 
 
 ## Section 3 - Entity classes Not Belonging to the Material Hierarchy

--- a/windows/ManuscriptaTeacherApp/docs/specifications/FrontendWorkflowSpecifications.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/FrontendWorkflowSpecifications.md
@@ -143,7 +143,7 @@ For a list of all server method and client handlers to be implemented for commun
 
     (b) modify the reading age and actual age metadata of the material.
 
-    (c) undo and redo changes to the material.
+    (c) undo and redo changes to the material.  
 
 (3) **Saving Content**
 
@@ -172,6 +172,32 @@ For a list of all server method and client handlers to be implemented for commun
         However, this button shall not be provided when the material is a poll. [Explanatory note: this is because polls must have exactly one multiple choice question]
 
     (d) not allow the user to delete questions through any other means than the delete button specified in paragraph (c).
+
+(3A) **Editing Questions**
+
+    The frontend shall -
+
+    (a) collect the following information regarding the question the user wishes to edit:
+
+        (i) the question type, per s2B(1)(b) of the Validation Rules;
+
+        (ii) the question text, per s2B(1)(c) of the Validation Rules; and
+
+        (iii) an optional maximum score, per s2B(2)(c) of the Validation Rules.
+    
+    (b) in the case of a multiple choice question, collect the following additional information:
+
+        (i) the options, per s2B(2)(a) of the Validation Rules;
+
+        (ii) the correct option, per s2B(2)(b) of the Validation Rules;
+
+        and clearly indicate that the correct field is optional, and by selecting an option, the user indicates that automarking should be enabled for that question.
+    
+    (c) in the case of a short answer question, collect whether the user wishes to enable automarking for that question, and if so, collect the means by which the answer should be marked -
+
+        (i) in the case of exact match, collect the expected answer, and subsequently store that as `CorrectAnswer` per s2B(2)(b) of the Validation Rules when saved; or
+
+        (ii) in the case of AI-marking, collect a mark scheme, and subsequently store that as `MarkScheme` per s2E(1)(a) of the Additional Validation Rules when saved. 
 
 (4) **Handling attachments**
 


### PR DESCRIPTION
Explanatory note:

As decided earlier, the existence of the `CorrectAnswer` field suggests that the client should auto-mark responses based on the `CorrectAnswer` field.

However, this is unsuitable for AI-based auto-marking which should be done by the Windows device's AI capabilities. 

The Windows-side `MarkScheme` field therefore suggests that the question should be AI-marked. It should not coexist with the `CorrectAnswer` field.