### PR TITLE
[Windows] Fix serialisation violations

### DIFF
--- a/windows/ManuscriptaTeacherApp/Main/Controllers/DistributionController.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Controllers/DistributionController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 
+using Main.Models.Dtos;
 using Main.Services;
 
 namespace Main.Controllers;
@@ -67,10 +68,12 @@ public class DistributionController : ControllerBase
                 parsedDeviceId);
 
             // Per API Contract §2.5: Response format
+            // Per AdditionalValidationRules s1A(2): Use Android DTOs to exclude Windows-only fields
+            // Per AdditionalValidationRules s1A(3): Flat composition-like structure
             return Ok(new
             {
-                materials = bundle.Materials,
-                questions = bundle.Questions
+                materials = bundle.Materials.Select(AndroidMaterialDto.FromEntity),
+                questions = bundle.Questions.Select(AndroidQuestionDto.FromEntity)
             });
         }
         catch (Exception ex)

--- a/windows/ManuscriptaTeacherApp/Main/Models/Dtos/AndroidMaterialDto.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Models/Dtos/AndroidMaterialDto.cs
@@ -1,0 +1,44 @@
+using Main.Models.Enums;
+using Main.Models.Entities.Materials;
+using System.Text.Json.Nodes;
+
+namespace Main.Models.Dtos;
+
+/// <summary>
+/// DTO for MaterialEntity when communicating with Android clients.
+/// Per AdditionalValidationRules s1A(2): Excludes Windows-only fields (LessonId, ReadingAge, ActualAge).
+/// Per AdditionalValidationRules s1A(3): Flat composition-like structure matching Validation Rules §2A.
+/// </summary>
+public record AndroidMaterialDto(
+    Guid Id,
+    MaterialType MaterialType,
+    string Title,
+    string Content,
+    long Timestamp,
+    string? Metadata,
+    JsonArray? VocabularyTerms)
+{
+    /// <summary>
+    /// Maps a polymorphic MaterialEntity to an AndroidMaterialDto.
+    /// Excludes Windows-only fields per s1A(2).
+    /// </summary>
+    public static AndroidMaterialDto FromEntity(MaterialEntity entity)
+    {
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
+        // Convert DateTime to Unix timestamp (long) per Validation Rules §2A(1)(d)
+        var unixTimestamp = new DateTimeOffset(entity.Timestamp).ToUnixTimeSeconds();
+
+        return new AndroidMaterialDto(
+            Id: entity.Id,
+            MaterialType: entity.MaterialType,
+            Title: entity.Title,
+            Content: entity.Content,
+            Timestamp: unixTimestamp,
+            Metadata: entity.Metadata,
+            VocabularyTerms: entity.VocabularyTerms
+        );
+        // Note: LessonId, ReadingAge, ActualAge excluded per s1A(2)
+    }
+}

--- a/windows/ManuscriptaTeacherApp/Main/Models/Dtos/AndroidQuestionDto.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Models/Dtos/AndroidQuestionDto.cs
@@ -1,0 +1,53 @@
+using Main.Models.Enums;
+using Main.Models.Entities.Questions;
+
+namespace Main.Models.Dtos;
+
+/// <summary>
+/// DTO for QuestionEntity when communicating with Android clients.
+/// Per AdditionalValidationRules s1A(2): Excludes Windows-only fields (MarkScheme).
+/// Per AdditionalValidationRules s1A(3): Flat composition-like structure matching Validation Rules §2B.
+/// </summary>
+public record AndroidQuestionDto(
+    Guid Id,
+    Guid MaterialId,
+    QuestionType QuestionType,
+    string QuestionText,
+    List<string>? Options,
+    object? CorrectAnswer,
+    int? MaxScore)
+{
+    /// <summary>
+    /// Maps a polymorphic QuestionEntity to an AndroidQuestionDto.
+    /// Excludes Windows-only fields per s1A(2).
+    /// </summary>
+    public static AndroidQuestionDto FromEntity(QuestionEntity entity)
+    {
+        if (entity == null)
+            throw new ArgumentNullException(nameof(entity));
+
+        return entity switch
+        {
+            MultipleChoiceQuestionEntity mc => new AndroidQuestionDto(
+                Id: mc.Id,
+                MaterialId: mc.MaterialId,
+                QuestionType: mc.QuestionType,
+                QuestionText: mc.QuestionText,
+                Options: mc.Options?.ToList(),
+                CorrectAnswer: mc.CorrectAnswerIndex,  // int? for MC
+                MaxScore: mc.MaxScore
+            ),
+            WrittenAnswerQuestionEntity wa => new AndroidQuestionDto(
+                Id: wa.Id,
+                MaterialId: wa.MaterialId,
+                QuestionType: wa.QuestionType,
+                QuestionText: wa.QuestionText,
+                Options: null,
+                CorrectAnswer: wa.CorrectAnswer,  // string? for written answer
+                MaxScore: wa.MaxScore
+                // Note: MarkScheme excluded per s1A(2)
+            ),
+            _ => throw new InvalidOperationException($"Unknown question entity type: {entity.GetType().Name}")
+        };
+    }
+}

--- a/windows/ManuscriptaTeacherApp/Main/Program.cs
+++ b/windows/ManuscriptaTeacherApp/Main/Program.cs
@@ -56,10 +56,21 @@ builder.Services.AddSingleton<IDistributionService, DistributionService>();
 builder.Services.AddHostedService<HubEventBridge>();
 
 // NOTE: Controllers are enabled so that REST controllers can be added later.
-builder.Services.AddControllers();
+// Per AdditionalValidationRules.md s1A(1): PascalCase fields, SCREAMING_SNAKE_CASE enums
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        // s1A(1): Fields serialised in PascalCase (null = preserve original C# casing)
+        options.JsonSerializerOptions.PropertyNamingPolicy = null;
+        // s1A(1): Enum members serialised as SCREAMING_SNAKE_CASE strings
+        options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 builder.Services.AddSignalR()
     .AddJsonProtocol(options =>
     {
+        // s1A(1): Fields serialised in PascalCase (null = preserve original C# casing)
+        options.PayloadSerializerOptions.PropertyNamingPolicy = null;
+        // s1A(1): Enum members serialised as SCREAMING_SNAKE_CASE strings
         options.PayloadSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
     });
 

--- a/windows/ManuscriptaTeacherApp/MainTests/ControllersTests/DistributionControllerTests.cs
+++ b/windows/ManuscriptaTeacherApp/MainTests/ControllersTests/DistributionControllerTests.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Main.Controllers;
@@ -192,6 +195,416 @@ public class DistributionControllerTests
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result);
         Assert.NotNull(okResult.Value);
+    }
+
+    #endregion
+}
+
+/// <summary>
+/// Integration tests for DistributionController JSON serialisation compliance.
+/// Verifies AdditionalValidationRules.md Section 1A requirements:
+/// - s1A(1): PascalCase field names, SCREAMING_SNAKE_CASE enum values
+/// - s1A(2): Windows-only fields excluded from Android DTOs
+/// - s1A(3): Polymorphic entities serialised as flat composition-like structures
+/// </summary>
+public class DistributionControllerSerialisationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly Guid _testDeviceId = Guid.NewGuid();
+    private readonly Guid _testMaterialId = Guid.NewGuid();
+    private readonly Guid _testLessonId = Guid.NewGuid();
+
+    public DistributionControllerSerialisationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    #region s1A(1) - PascalCase Fields and SCREAMING_SNAKE_CASE Enums
+
+    [Fact]
+    public async Task GetDistribution_FieldNames_ArePascalCase()
+    {
+        // Arrange - Per s1A(1): Fields serialised in PascalCase
+        var material = new ReadingMaterialEntity(_testMaterialId, _testLessonId, "Test Material", "Content");
+        var questions = new List<QuestionEntity>
+        {
+            new MultipleChoiceQuestionEntity(Guid.NewGuid(), _testMaterialId, "Question?", new List<string> { "A", "B" }, 0)
+        };
+        var bundle = new DistributionBundle(new[] { material }, questions);
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - Field names should be PascalCase (not camelCase)
+        Assert.Contains("\"MaterialType\"", content);
+        Assert.Contains("\"Title\"", content);
+        Assert.Contains("\"Content\"", content);
+        Assert.Contains("\"Timestamp\"", content);
+        Assert.Contains("\"QuestionType\"", content);
+        Assert.Contains("\"QuestionText\"", content);
+        Assert.Contains("\"Id\"", content);
+        
+        // Verify NOT camelCase
+        Assert.DoesNotContain("\"materialType\"", content);
+        Assert.DoesNotContain("\"title\"", content);
+        Assert.DoesNotContain("\"content\"", content);
+        Assert.DoesNotContain("\"timestamp\"", content);
+    }
+
+    [Fact]
+    public async Task GetDistribution_EnumValues_AreSCREAMING_SNAKE_CASE()
+    {
+        // Arrange - Per s1A(1): Enum members serialised in SCREAMING_SNAKE_CASE
+        var material = new WorksheetMaterialEntity(_testMaterialId, _testLessonId, "Test Worksheet Title", "Content");
+        var questions = new List<QuestionEntity>
+        {
+            new WrittenAnswerQuestionEntity(Guid.NewGuid(), _testMaterialId, "Question?", "Answer")
+        };
+        var bundle = new DistributionBundle(new[] { material }, questions);
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - Enum values should be SCREAMING_SNAKE_CASE strings
+        Assert.Contains("\"MaterialType\":\"WORKSHEET\"", content);
+        Assert.Contains("\"QuestionType\":\"WRITTEN_ANSWER\"", content);
+        
+        // Verify NOT numeric
+        Assert.DoesNotContain("\"MaterialType\":1", content);
+        Assert.DoesNotContain("\"QuestionType\":2", content);
+    }
+
+    #endregion
+
+    #region s1A(2) - Windows-Only Fields Excluded from Android DTOs
+
+    [Fact]
+    public async Task GetDistribution_Materials_ExcludeLessonId()
+    {
+        // Arrange - Per s1A(2): LessonId is Windows-only per AdditionalValidationRules §2D(1)(a)
+        var material = new ReadingMaterialEntity(_testMaterialId, _testLessonId, "Test Material", "Content");
+        var bundle = new DistributionBundle(new[] { material }, new List<QuestionEntity>());
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - LessonId should NOT be present in Android DTO
+        Assert.DoesNotContain("\"LessonId\"", content);
+        Assert.DoesNotContain("\"lessonId\"", content);
+    }
+
+    [Fact]
+    public async Task GetDistribution_Materials_ExcludeReadingAge()
+    {
+        // Arrange - Per s1A(2): ReadingAge/ActualAge are Windows-only per AdditionalValidationRules §2D(2)
+        var material = new ReadingMaterialEntity(
+            _testMaterialId, _testLessonId, "Test Material", "Content",
+            readingAge: 12, actualAge: 14);
+        var bundle = new DistributionBundle(new[] { material }, new List<QuestionEntity>());
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - ReadingAge and ActualAge should NOT be present
+        Assert.DoesNotContain("\"ReadingAge\"", content);
+        Assert.DoesNotContain("\"readingAge\"", content);
+        Assert.DoesNotContain("\"ActualAge\"", content);
+        Assert.DoesNotContain("\"actualAge\"", content);
+    }
+
+    [Fact]
+    public async Task GetDistribution_Questions_ExcludeMarkScheme()
+    {
+        // Arrange - Per s1A(2): MarkScheme is Windows-only per AdditionalValidationRules §2E(1)(a)
+        var material = new WorksheetMaterialEntity(_testMaterialId, _testLessonId, "Worksheet", "Content");
+        var questions = new List<QuestionEntity>
+        {
+            new WrittenAnswerQuestionEntity(Guid.NewGuid(), _testMaterialId, "Question?", null, markScheme: "Award 1 mark for correct answer")
+        };
+        var bundle = new DistributionBundle(new[] { material }, questions);
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - MarkScheme should NOT be present in Android DTO
+        Assert.DoesNotContain("\"MarkScheme\"", content);
+        Assert.DoesNotContain("\"markScheme\"", content);
+        Assert.DoesNotContain("Award 1 mark", content);
+    }
+
+    #endregion
+
+    #region s1A(3) - Polymorphic Entities as Flat Composition-like Structures
+
+    [Fact]
+    public async Task GetDistribution_Materials_SerialiseAsFlatStructure()
+    {
+        // Arrange - Per s1A(3): Polymorphic MaterialEntity should appear composition-like
+        var reading = new ReadingMaterialEntity(Guid.NewGuid(), _testLessonId, "Reading", "Content1");
+        var worksheet = new WorksheetMaterialEntity(Guid.NewGuid(), _testLessonId, "Worksheet", "Content2");
+        var poll = new PollMaterialEntity(Guid.NewGuid(), _testLessonId, "Poll", "Content3");
+        
+        var materials = new List<MaterialEntity> { reading, worksheet, poll };
+        var bundle = new DistributionBundle(materials, new List<QuestionEntity>());
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - Should have flat structure with MaterialType discriminator
+        Assert.Contains("\"READING\"", content);
+        Assert.Contains("\"WORKSHEET\"", content);
+        Assert.Contains("\"POLL\"", content);
+        
+        // Should NOT have type discriminator metadata
+        Assert.DoesNotContain("\"$type\"", content);
+        Assert.DoesNotContain("ReadingMaterialEntity", content);
+        Assert.DoesNotContain("WorksheetMaterialEntity", content);
+        Assert.DoesNotContain("PollMaterialEntity", content);
+    }
+
+    [Fact]
+    public async Task GetDistribution_Questions_SerialiseAsFlatStructure()
+    {
+        // Arrange - Per s1A(3): Polymorphic QuestionEntity should appear composition-like
+        var material = new WorksheetMaterialEntity(_testMaterialId, _testLessonId, "Worksheet", "Content");
+        var questions = new List<QuestionEntity>
+        {
+            new MultipleChoiceQuestionEntity(Guid.NewGuid(), _testMaterialId, "MC Question?", new List<string> { "A", "B" }, 0),
+            new WrittenAnswerQuestionEntity(Guid.NewGuid(), _testMaterialId, "WA Question?", "Answer")
+        };
+        var bundle = new DistributionBundle(new[] { material }, questions);
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+
+        // Assert - Should have flat structure with QuestionType discriminator
+        Assert.Contains("\"MULTIPLE_CHOICE\"", content);
+        Assert.Contains("\"WRITTEN_ANSWER\"", content);
+        
+        // Should NOT have type discriminator metadata
+        Assert.DoesNotContain("\"$type\"", content);
+        Assert.DoesNotContain("MultipleChoiceQuestionEntity", content);
+        Assert.DoesNotContain("WrittenAnswerQuestionEntity", content);
+    }
+
+    [Fact]
+    public async Task GetDistribution_Materials_ContainAllRequiredFields()
+    {
+        // Arrange - Per Validation Rules §2A: Required fields for MaterialEntity
+        var material = new ReadingMaterialEntity(
+            _testMaterialId, _testLessonId, "Test Title", "Test Content",
+            metadata: "test metadata");
+        var bundle = new DistributionBundle(new[] { material }, new List<QuestionEntity>());
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var materials = json.RootElement.GetProperty("materials").EnumerateArray().First();
+
+        // Assert - All required fields from Validation Rules §2A should be present
+        Assert.True(materials.TryGetProperty("Id", out _), "Id field missing");
+        Assert.True(materials.TryGetProperty("MaterialType", out _), "MaterialType field missing");
+        Assert.True(materials.TryGetProperty("Title", out _), "Title field missing");
+        Assert.True(materials.TryGetProperty("Content", out _), "Content field missing");
+        Assert.True(materials.TryGetProperty("Timestamp", out _), "Timestamp field missing");
+    }
+
+    [Fact]
+    public async Task GetDistribution_Questions_ContainAllRequiredFields()
+    {
+        // Arrange - Per Validation Rules §2B: Required fields for QuestionEntity
+        var material = new WorksheetMaterialEntity(_testMaterialId, _testLessonId, "Worksheet", "Content");
+        var questions = new List<QuestionEntity>
+        {
+            new MultipleChoiceQuestionEntity(Guid.NewGuid(), _testMaterialId, "Question?", new List<string> { "A", "B" }, 0, maxScore: 5)
+        };
+        var bundle = new DistributionBundle(new[] { material }, questions);
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var question = json.RootElement.GetProperty("questions").EnumerateArray().First();
+
+        // Assert - All required fields from Validation Rules §2B should be present
+        Assert.True(question.TryGetProperty("Id", out _), "Id field missing");
+        Assert.True(question.TryGetProperty("MaterialId", out _), "MaterialId field missing");
+        Assert.True(question.TryGetProperty("QuestionType", out _), "QuestionType field missing");
+        Assert.True(question.TryGetProperty("QuestionText", out _), "QuestionText field missing");
+    }
+
+    #endregion
+
+    #region Timestamp Format Tests
+
+    [Fact]
+    public async Task GetDistribution_Materials_TimestampIsUnixLong()
+    {
+        // Arrange - Per Validation Rules §2A(1)(d): Timestamp should be a Unix timestamp (long)
+        var material = new ReadingMaterialEntity(_testMaterialId, _testLessonId, "Test", "Content");
+        var bundle = new DistributionBundle(new[] { material }, new List<QuestionEntity>());
+
+        var mockDistributionService = new Mock<IDistributionService>();
+        mockDistributionService.Setup(x => x.GetDistributionBundleAsync(_testDeviceId))
+            .ReturnsAsync(bundle);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IDistributionService));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddSingleton(mockDistributionService.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var response = await client.GetAsync($"/api/v1/distribution/{_testDeviceId}");
+        var content = await response.Content.ReadAsStringAsync();
+        var json = JsonDocument.Parse(content);
+        var materials = json.RootElement.GetProperty("materials").EnumerateArray().First();
+
+        // Assert - Timestamp should be a number (Unix timestamp), not an ISO string
+        var timestamp = materials.GetProperty("Timestamp");
+        Assert.Equal(JsonValueKind.Number, timestamp.ValueKind);
+        
+        // Should be a reasonable Unix timestamp (after year 2020)
+        var timestampValue = timestamp.GetInt64();
+        Assert.True(timestampValue > 1577836800, "Timestamp should be a Unix timestamp after 2020");
     }
 
     #endregion

--- a/windows/ManuscriptaTeacherApp/MainTests/ControllersTests/FeedbackControllerTests.cs
+++ b/windows/ManuscriptaTeacherApp/MainTests/ControllersTests/FeedbackControllerTests.cs
@@ -1,4 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Main.Controllers;
@@ -223,4 +225,64 @@ public class FeedbackControllerTests
     }
 
     #endregion
+}
+
+/// <summary>
+/// Integration tests for FeedbackController JSON serialisation compliance.
+/// Verifies AdditionalValidationRules.md Section 1A(1): PascalCase field names.
+/// </summary>
+public class FeedbackControllerSerialisationTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly Guid _testDeviceId = Guid.NewGuid();
+    private readonly Guid _testResponseId = Guid.NewGuid();
+    private readonly Guid _testQuestionId = Guid.NewGuid();
+
+    public FeedbackControllerSerialisationTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task GetFeedback_FieldNames_ArePascalCase()
+    {
+        // Arrange - Per s1A(1): Fields serialised in PascalCase
+        var feedback = new FeedbackEntity(Guid.NewGuid(), _testResponseId, text: "Good work!", marks: 5);
+        var response = new WrittenAnswerResponseEntity(_testResponseId, _testQuestionId, _testDeviceId, "Answer");
+
+        var mockFeedbackRepo = new Mock<IFeedbackRepository>();
+        mockFeedbackRepo.Setup(r => r.GetAllAsync()).ReturnsAsync(new[] { feedback });
+
+        var mockResponseRepo = new Mock<IResponseRepository>();
+        mockResponseRepo.Setup(r => r.GetByIdAsync(_testResponseId)).ReturnsAsync(response);
+
+        var client = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                var feedbackDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IFeedbackRepository));
+                if (feedbackDescriptor != null) services.Remove(feedbackDescriptor);
+                services.AddSingleton(mockFeedbackRepo.Object);
+
+                var responseDescriptor = services.SingleOrDefault(d => d.ServiceType == typeof(IResponseRepository));
+                if (responseDescriptor != null) services.Remove(responseDescriptor);
+                services.AddSingleton(mockResponseRepo.Object);
+            });
+        }).CreateClient();
+
+        // Act
+        var httpResponse = await client.GetAsync($"/api/v1/feedback/{_testDeviceId}");
+        var content = await httpResponse.Content.ReadAsStringAsync();
+
+        // Assert - Field names should be PascalCase
+        Assert.Contains("\"Id\"", content);
+        Assert.Contains("\"ResponseId\"", content);
+        Assert.Contains("\"Text\"", content);
+        Assert.Contains("\"Marks\"", content);
+        
+        // Verify NOT camelCase
+        Assert.DoesNotContain("\"responseId\"", content);
+        Assert.DoesNotContain("\"text\":", content);
+        Assert.DoesNotContain("\"marks\":", content);
+    }
 }

--- a/windows/ManuscriptaTeacherApp/docs/specifications/AdditionalValidationRules.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/AdditionalValidationRules.md
@@ -24,6 +24,14 @@ This document defines the hierarchical system for grouping and organising Materi
 
 (6) For the purpose of this document, "contain" in relation to a data field means "contain a non-null value for".
 
+## Section 1A - Serialisation
+
+(1) Pursuant to Validation Rules s1(6), fields in JSON objects shall be serialised in PascalCase, whilst enum members shall be serialised in SCREAMING_SNAKE_CASE.
+
+(2) Unless otherwise specified, any fields defined in this document shall not appear in the data transfer objects used in communication with the android client.
+
+(3) Care must be taken to ensure polymorphic classes[, such as Materials, Questions and Responses] are appropriately serialised, such that they appear in a composition-like manner as specified in the Validation Rules.
+
 ## Section 2 - Entity classes for Each Hierarchical Level
 
 ### Section 2A - Unit Collection
@@ -67,8 +75,6 @@ This document defines the hierarchical system for grouping and organising Materi
     (a) `ReadingAge` (int).
     (b) `ActualAge` (int).
 
-(3) Additional fields defined in this Section shall not appear in the Data Transfer Objects (DTOs) used for communication with the Android client, specified in the API Contract.
-
 
 ### Section 2E - Question
 
@@ -81,8 +87,6 @@ This document defines the hierarchical system for grouping and organising Materi
     (a) A `QuestionEntity` object of type `MULTIPLE_CHOICE` must not have a `MarkScheme` defined in (1)(a).
 
     (b) A `QuestionEntity` object may not simultaneously contain `MarkScheme` and `CorrectAnswer` fields.
-
-(3) Additional fields defined in this Section shall not appear in the Data Transfer Objects (DTOs) used for communication with the Android client, specified in the API Contract.
 
 
 ## Section 3 - Entity classes Not Belonging to the Material Hierarchy


### PR DESCRIPTION
It has been observed that the current serialisation settings violate multiple specification points, namely:

1. Use of PascalCase for fields and SCREAMING_SNAKE_CASE for enum members - by default, ASP.NET Core serialises field names into camelCase and enum members as integers.
2. Fields defined in Additional Validation Rules not to be included in DTOs.
3. Correct serialisation of polymorphic fields.

Point 1 is addressed by adding additional serialisation settings to Program.cs. Points 2-3 are addressed by defining Android-facing DTOs to flatten the inheritance tree and exclude windows-specific fields.

Tests are also added to check for actual serialisation.

Note that I have also solidified serialisation principles in AdditionalValidationRules.