### PR TITLE
[Android] [Docs] Add Android team PR conventions

### DIFF
--- a/docs/Github Conventions.md
+++ b/docs/Github Conventions.md
@@ -34,6 +34,7 @@ Each issue or pull request, if applicable, should be marked with either an ```an
 
 A pull request should only be merged after it is approved by the other member of your subteam. Each subteam may request PR reviews from the other subteam should they deem the PR to be of considerable significance.
 
+
 ## Documentation
 
 All forms of system-wide documentation should be stored as Markdown files in the ```docs``` directory. Any change to this directory's contents must be approved by all team members via a PR.


### PR DESCRIPTION
## Summary
Following our team discussion, this PR adds `android/docs/android-team-conventions.md` to document conventions specific to the Android subteam's workflow.

## Changes
### Android Conventions
- Adds `android/docs/android-team-conventions.md` with:
    - **PR Workflow**: Detailed process for opening and reviewing PRs.
    - **Merging Prerequisites**: Checklist for merge readiness.
    - **Communication**: Guidelines for human-written content.
    - Adds a rule to `docs/Github Conventions.md`: Issues can only be closed once their respective branch is merged.