### PR TITLE
[Windows] Added search bar to lesson library

### DIFF
--- a/windows/ManuscriptaTeacherApp/UI/src/renderer/components/pages/LessonLibraryPage.tsx
+++ b/windows/ManuscriptaTeacherApp/UI/src/renderer/components/pages/LessonLibraryPage.tsx
@@ -11,6 +11,7 @@ import { CreateUnitModal } from '../modals/CreateUnitModal';
 import { CreateLessonModal } from '../modals/CreateLessonModal';
 import { CreateMaterialModal } from '../modals/CreateMaterialModal';
 import { EditorModal } from '../editor/EditorModal';
+import { markdownToHtml } from '../../utils/markdownConversion';
 import type { UnitCollectionEntity, UnitEntity, LessonEntity, MaterialEntity, MaterialType } from '../../models';
 
 // Icons from prototype LibraryVariantTree.tsx
@@ -96,6 +97,18 @@ export const LessonLibraryPage: React.FC = () => {
     );
     const isSearching = searchKeywords.length > 0;
 
+    const getVisibleTextFromContent = (content: string) => {
+        if (!content.trim()) return '';
+        const html = markdownToHtml(content);
+        const text = html
+            .replace(/<[^>]*>/g, ' ')
+            .replace(/\[Question:\s*[^\]]+\]/gi, ' ')
+            .replace(/\[PDF:\s*[^\]]+\]/gi, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        return text;
+    };
+
     const filteredMaterialsByLesson = useMemo(() => {
         const result = new Map<string, MaterialEntity[]>();
         const materialMatchesSearch = (material: MaterialEntity) => {
@@ -103,12 +116,11 @@ export const LessonLibraryPage: React.FC = () => {
             const questionText = getQuestionsForMaterial(material.id)
                 .map(question => {
                     const options = question.options?.join(' ') ?? '';
-                    const correctAnswer = question.correctAnswer ?? '';
-                    const markScheme = question.markScheme ?? '';
-                    return `${question.questionText} ${options} ${correctAnswer} ${markScheme}`;
+                    return `${question.questionText} ${options}`;
                 })
                 .join(' ');
-            const haystack = `${material.title} ${material.content || ''} ${questionText}`.toLowerCase();
+            const visibleContent = getVisibleTextFromContent(material.content || '');
+            const haystack = `${material.title} ${visibleContent} ${questionText}`.toLowerCase();
             return searchKeywords.every(keyword => haystack.includes(keyword));
         };
 

--- a/windows/ManuscriptaTeacherApp/docs/specifications/FrontendWorkflowSpecifications.md
+++ b/windows/ManuscriptaTeacherApp/docs/specifications/FrontendWorkflowSpecifications.md
@@ -217,7 +217,13 @@ For a list of all server method and client handlers to be implemented for commun
 
 (2) When the frontend creates, updates or deletes a unit collection, unit, lesson or material, it must call the appropriate CRUD method defined in S1(1)(a)-(d) of `NetworkingAPISpec.md`.
 
-(3) The "Library" tab must provide a search bar for searching materials in the lesson library. When one or more keywords are entered into the search bar, the frontend must filter through all materials in the lesson library and only display those whose title, content or questions include those keywords.
+(3) The "Library" tab must provide a search bar for searching materials in the lesson library, subject to the following requirements.
+
+    (a) When one or more keywords are entered into the search bar, the frontend must filter through all materials in the lesson library and only display those matching those keywords.
+
+    (b) Materials are said to match the keyword if its title, content, question texts or question options include the keyword.
+
+    (c) Material encoding syntax that is not visible through the user interface must be excluded from the search. 
 
 
 


### PR DESCRIPTION
Adds the material searching functionality which was previously mentioned in FrontendWorkflowSpecifications but missing from the frontend implementation.

Also includes related specification changes.

Questions to consider:
1. Should punctuation symbols be discarded from the list of inputted search keywords?
2. What about Markdown syntax? The current implementation means that if a material contains bold text, it will appear as a search result given the search input `*`.